### PR TITLE
u0 shouldn't be recommended for iOS 12.4.9, it doesn't work on 12.4.9

### DIFF
--- a/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-air).md
+++ b/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-air).md
@@ -83,6 +83,11 @@ Your device version can be found in the Settings application in `General` -> `Ab
     </tr>
     <tr>
       <td>12.4.1</td>
+      <td>12.4.8</td>
+      <td><a href="installing-unc0ver">Installing unc0ver</a></td>
+    </tr>
+    <tr>
+      <td>12.4.9</td>
       <td>12.4.9</td>
       <td><a href="installing-checkra1n">Installing checkra1n</a></td>
     </tr>

--- a/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-mini-2).md
+++ b/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-mini-2).md
@@ -82,8 +82,13 @@ Your device version can be found in the Settings application in `General` -> `Ab
     </tr>
     <tr>
       <td>12.4.1</td>
-      <td>12.4.9</td>
+      <td>12.4.8</td>
       <td><a href="installing-unc0ver">Installing unc0ver</a></td>
+    </tr>
+    <tr>
+      <td>12.4.9</td>
+      <td>12.4.9</td>
+      <td><a href="installing-checkra1n">Installing checkra1n</a></td>
     </tr>
   </tbody>
 </table>

--- a/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-mini-3).md
+++ b/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-mini-3).md
@@ -82,8 +82,13 @@ Your device version can be found in the Settings application in `General` -> `Ab
     </tr>
     <tr>
       <td>12.4.1</td>
-      <td>12.4.9</td>
+      <td>12.4.8</td>
       <td><a href="installing-unc0ver">Installing unc0ver</a></td>
+    </tr>
+    <tr>
+      <td>12.4.9</td>
+      <td>12.4.9</td>
+      <td><a href="installing-checkra1n">Installing checkra1n</a></td>
     </tr>
   </tbody>
 </table>

--- a/_pages/en_US/device-selection/iphone-ipod/firmware-selection-(iphone-5s).md
+++ b/_pages/en_US/device-selection/iphone-ipod/firmware-selection-(iphone-5s).md
@@ -78,7 +78,7 @@ Your device version can be found in the Settings application in `General` -> `Ab
     <tr>
       <td>12.3</td>
       <td>12.3.1</td>
-      <td><a href="installing-checkra1n">Installing checkra1n</a></td>
+      <td><a href="installing-unc0ver">Installing unc0ver</a></td>
     </tr>
     <tr>
       <td>12.4</td>
@@ -87,8 +87,13 @@ Your device version can be found in the Settings application in `General` -> `Ab
     </tr>
     <tr>
       <td>12.4.1</td>
-      <td>12.4.9</td>
+      <td>12.4.8</td>
       <td><a href="installing-unc0ver">Installing unc0ver</a></td>
+    </tr>
+    <tr>
+      <td>12.4.9</td>
+      <td>12.4.9</td>
+      <td><a href="installing-checkra1n">Installing checkra1n</a></td>
     </tr>
   </tbody>
 </table>

--- a/_pages/en_US/device-selection/iphone-ipod/firmware-selection-(iphone-6).md
+++ b/_pages/en_US/device-selection/iphone-ipod/firmware-selection-(iphone-6).md
@@ -82,8 +82,13 @@ Your device version can be found in the Settings application in `General` -> `Ab
     </tr>
     <tr>
       <td>12.4.1</td>
-      <td>12.4.9</td>
+      <td>12.4.8</td>
       <td><a href="installing-unc0ver">Installing unc0ver</a></td>
+    </tr>
+    <tr>
+      <td>12.4.9</td>
+      <td>12.4.9</td>
+      <td><a href="installing-checkra1n">Installing checkra1n</a></td>
     </tr>
   </tbody>
 </table>

--- a/_pages/en_US/device-selection/iphone-ipod/firmware-selection-(ipod-touch-6).md
+++ b/_pages/en_US/device-selection/iphone-ipod/firmware-selection-(ipod-touch-6).md
@@ -33,13 +33,12 @@ Your device version can be found in the Settings application in `General` -> `Ab
     <tr>
       <td>8.0</td>
       <td>8.4</td>
-      <td colspan="2">Coming Soon</td>
+      <td>Coming Soon</td>
     </tr>
     <tr>
       <td>8.4.1</td>
       <td>8.4.1</td>
       <td><a href="updating-to-12-4-9">Updating to 12.4.9</a></td>
-      <td>--</td>
     </tr>
     <tr>
       <td>9.0</td>
@@ -73,18 +72,18 @@ Your device version can be found in the Settings application in `General` -> `Ab
     </tr>
     <tr>
       <td>12.4</td>
+      <td>12.4</td>
+      <td><a href="installing-chimera">Installing Chimera</a></td>
+    </tr>
+    <tr>
       <td>12.4.1</td>
-      <td><a href="installing-unc0ver">Installing unc0ver</a></td>
-    </tr>
-    <tr>
-      <td>12.4.2</td>
-      <td>12.4.7</td>
-      <td><a href="installing-checkra1n">Installing checkra1n</a></td>
-    </tr>
-    <tr>
       <td>12.4.8</td>
-      <td>12.4.9</td>
       <td><a href="installing-unc0ver">Installing unc0ver</a></td>
+    </tr>
+    <tr>
+      <td>12.4.9</td>
+      <td>12.4.9</td>
+      <td><a href="installing-checkra1n">Installing checkra1n</a></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
u0 doesn't actually work on iOS 12.4.9, we do not know whether or not it was patched, but either way, when you try to use it, it'll say "unsupported" if you're on 12.4.9.