### PR TITLE
Add OTA to 6.1.3 or 8.4.1 for most devices capable of doing so.

### DIFF
--- a/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-2).md
+++ b/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-2).md
@@ -54,6 +54,21 @@ Your device version can be found in the Settings application in `General` -> `Ab
     </tr>
     <tr>
       <td>5.0</td>
+      <td>5.0</td>
+      <td colspan="2"><a href="updating-to-6-1-3">Updating to 6.1.3</a></td>
+    </tr>
+	<tr>
+      <td>5.0.1</td>
+      <td>5.0.1</td>
+      <td colspan="2">Coming Soon</td>
+    </tr>
+	<tr>
+      <td>5.1</td>
+      <td>5.1</td>
+      <td colspan="2"><a href="updating-to-6-1-3">Updating to 6.1.3</a></td>
+    </tr>
+	<tr>
+      <td>5.1.1</td>
       <td>6.1.2</td>
       <td colspan="2">Coming Soon</td>
     </tr>

--- a/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-3).md
+++ b/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-3).md
@@ -35,6 +35,11 @@ Your device version can be found in the Settings application in `General` -> `Ab
   <tbody>
   <tr>
       <td>5.1</td>
+      <td>5.1</td>
+      <td><a href="updating-to-8-4-1">Updating to 8.4.1</a></td>
+    </tr>
+  <tr>
+      <td>5.1.1</td>
       <td>6.1.2</td>
       <td>Coming Soon</td>
     </tr>

--- a/_pages/en_US/device-selection/iphone-ipod/firmware-selection-(iphone-4s).md
+++ b/_pages/en_US/device-selection/iphone-ipod/firmware-selection-(iphone-4s).md
@@ -35,6 +35,16 @@ Your device version can be found in the Settings application in `General` -> `Ab
   <tbody>
     <tr>
       <td>5.0</td>
+      <td>5.0.1</td>
+      <td>Coming Soon</td>
+    </tr>
+	<tr>
+      <td>5.1</td>
+      <td>5.1</td>
+      <td><a href="updating-to-6-1-3">Updating to 6.1.3</a></td>
+    </tr>
+	<tr>
+      <td>5.1.1</td>
       <td>6.1.2</td>
       <td>Coming Soon</td>
     </tr>

--- a/_pages/en_US/updating-to-6.1.3.md
+++ b/_pages/en_US/updating-to-6.1.3.md
@@ -1,0 +1,36 @@
+---
+title: Updating to 6.1.3
+permalink: /updating-to-6-1-3
+---
+
+{% include toc title="Table of Contents" %}
+
+## Required Reading
+
+Unfortunately, there is currently no jailbreak available for firmware versions 5.0 or 5.1 to on most A5 devices. However devices, such as the iPhone 4S, can update to 6.1.3 and use p0sixspwn instead.
+
+This is achieved by simply updating through the Settings application normally. Because the latest available OTA version for their current firmware on these devices is 6.1.3, we can easily update to the desired firmware version, due to the age of their curremt firmware version.
+
+If you have installed update blocking via tvOS Beta profiles, you must first remove that profile before updating. If you don't know what this means, ignore this.
+
+## Removing Profiles
+
+Only follow this if you've installed update blocking in the past.
+{: .notice--info}
+
+1. Open the Settings application
+1. Tap `General` -> `Profile`
+  - This may also be called `Profile and Device Management`
+1. Tap on the tvOS Beta Software Profile
+  - If this is not there, you can skip to the next section of the guide
+1. Tap `Remove Downloaded Profile`
+
+## Updating to 6.1.3
+
+1. Plug your device into power and connect to the Internet with Wi-Fi
+1. Tap `Settings` -> `General` -> `Software Update`
+  - Ensure that the version you are updating to is 6.1.3
+1. Download and install the update
+
+Continue to [Installing p0sixspwn](installing-p0sixspwn)
+{: .notice--info}

--- a/_pages/en_US/updating-to-8.4.1.md
+++ b/_pages/en_US/updating-to-8.4.1.md
@@ -15,14 +15,13 @@ If you have installed update blocking via tvOS Beta profiles, you must first rem
 
 ## Removing Profiles
 
-Only follow this if you've installed update blocking in the past.
+Only follow this if you've installed an update-blocking profile in the past.
 {: .notice--info}
 
 1. Open the Settings application
 1. Tap `General` -> `Profile`
   - This may also be called `Profile and Device Management`
 1. Tap on the tvOS Beta Software Profile
-  - If this is not there, you can skip to the next section of the guide
 1. Tap `Remove Downloaded Profile`
 
 ## Updating to 8.4.1

--- a/_pages/en_US/updating-to-8.4.1.md
+++ b/_pages/en_US/updating-to-8.4.1.md
@@ -1,0 +1,36 @@
+---
+title: Updating to 8.4.1
+permalink: /updating-to-8-4-1
+---
+
+{% include toc title="Table of Contents" %}
+
+## Required Reading
+
+Unfortunately, there is currently no jailbreak available for firmware version 5.1 to on the iPad 3rd Generation. However, this device can update to 8.4.1 and use EtasonJB instead.
+
+This is achieved by simply updating through the Settings application normally. Because the latest available OTA version for their current firmware on these devices is 8.4.1, we can easily update to the desired firmware version, due to the age of their curremt firmware version.
+
+If you have installed update blocking via tvOS Beta profiles, you must first remove that profile before updating. If you don't know what this means, ignore this.
+
+## Removing Profiles
+
+Only follow this if you've installed update blocking in the past.
+{: .notice--info}
+
+1. Open the Settings application
+1. Tap `General` -> `Profile`
+  - This may also be called `Profile and Device Management`
+1. Tap on the tvOS Beta Software Profile
+  - If this is not there, you can skip to the next section of the guide
+1. Tap `Remove Downloaded Profile`
+
+## Updating to 8.4.1
+
+1. Plug your device into power and connect to the Internet with Wi-Fi
+1. Tap `Settings` -> `General` -> `Software Update`
+  - Ensure that the version you are updating to is 8.4.1
+1. Download and install the update
+
+Continue to [Installing EtasonJB](installing-EtasonJB)
+{: .notice--info}


### PR DESCRIPTION
A jailbreak for devices on 5.0 for A5 iPad's and 5.1 for all A5(X) devices, while a thing, is tethered and something that I wouldn't recommend to new users who want to jailbreak their old devices.

This PR implements the OTA update pages for the following devices and versions:
- For the iPad 2 and iPhone 4S, iOS 6.1.3.
- For the iPad 3rd Generation, iOS 8.4.1.