### PR TITLE
Bump possible devices with preinstalled/factory 10.0 to 10.0 rather than 10.0.1

### DIFF
--- a/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-air).md
+++ b/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-air).md
@@ -61,7 +61,7 @@ Your device version can be found in the Settings application in `General` -> `Ab
       <td><a href="updating-to-10-3-3">Updating to 10.3.3</a></td>
     </tr>
     <tr>
-      <td>10.0.1</td>
+      <td>10.0</td>
       <td>10.3.3</td>
       <td><a href="using-meridian">Using Meridian</a></td>
     </tr>

--- a/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-air-2).md
+++ b/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-air-2).md
@@ -59,7 +59,7 @@ Your device version can be found in the Settings application in `General` -> `Ab
       <td><a href="updating-to-14-2">Updating to {% include latestfw %}</a></td>
     </tr>
     <tr>
-      <td>10.0.1</td>
+      <td>10.0</td>
       <td>10.3.3</td>
       <td><a href="using-meridian">Using Meridian</a></td>
     </tr>

--- a/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-mini-2).md
+++ b/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-mini-2).md
@@ -59,7 +59,7 @@ Your device version can be found in the Settings application in `General` -> `Ab
       <td><a href="updating-to-12-4-9">Updating to 12.4.9</a></td>
     </tr>
     <tr>
-      <td>10.0.1</td>
+      <td>10.0</td>
       <td>10.3.3</td>
       <td><a href="using-meridian">Using Meridian</a></td>
     </tr>

--- a/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-mini-3).md
+++ b/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-mini-3).md
@@ -59,7 +59,7 @@ Your device version can be found in the Settings application in `General` -> `Ab
       <td><a href="updating-to-12-4-9">Updating to 12.4.9</a></td>
     </tr>
     <tr>
-      <td>10.0.1</td>
+      <td>10.0</td>
       <td>10.3.3</td>
       <td><a href="using-meridian">Using Meridian</a></td>
     </tr>

--- a/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-mini-4).md
+++ b/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-mini-4).md
@@ -49,7 +49,7 @@ Your device version can be found in the Settings application in `General` -> `Ab
       <td><a href="updating-to-14-2">Updating to {% include latestfw %}</a></td>
     </tr>
     <tr>
-      <td>10.0.1</td>
+      <td>10.0</td>
       <td>10.3.3</td>
       <td><a href="using-meridian">Using Meridian</a></td>
     </tr>

--- a/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-pro).md
+++ b/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-pro).md
@@ -50,7 +50,7 @@ Your device version can be found in the Settings application in `General` -> `Ab
       <td><a href="updating-to-14-2">Updating to {% include latestfw %}</a></td>
     </tr>
     <tr>
-      <td>10.0.1</td>
+      <td>10.0</td>
       <td>10.3.3</td>
       <td><a href="using-meridian">Using Meridian</a></td>
     </tr>

--- a/_pages/en_US/device-selection/iphone-ipod/firmware-selection-(iphone-6s).md
+++ b/_pages/en_US/device-selection/iphone-ipod/firmware-selection-(iphone-6s).md
@@ -49,7 +49,7 @@ Your device version can be found in the Settings application in `General` -> `Ab
       <td><a href="updating-to-14-2">Updating to 14.2</a></td>
     </tr>
     <tr>
-      <td>10.0.1</td>
+      <td>10.0</td>
       <td>10.3.3</td>
       <td><a href="using-meridian">Using Meridian</a></td>
     </tr>

--- a/_pages/en_US/device-selection/iphone-ipod/firmware-selection-(iphone-7).md
+++ b/_pages/en_US/device-selection/iphone-ipod/firmware-selection-(iphone-7).md
@@ -34,7 +34,7 @@ Your device version can be found in the Settings application in `General` -> `Ab
   </thead>
   <tbody>
     <tr>
-      <td>10.0.1</td>
+      <td>10.0</td>
       <td>10.3.3</td>
       <td><a href="using-meridian">Using Meridian</a></td>
     </tr>

--- a/_pages/en_US/device-selection/iphone-ipod/firmware-selection-(iphone-se).md
+++ b/_pages/en_US/device-selection/iphone-ipod/firmware-selection-(iphone-se).md
@@ -44,7 +44,7 @@ Your device version can be found in the Settings application in `General` -> `Ab
       <td><a href="updating-to-14-2">Updating to 14.2</a></td>
     </tr>
     <tr>
-      <td>10.0.1</td>
+      <td>10.0</td>
       <td>10.3.3</td>
       <td><a href="using-meridian">Using Meridian</a></td>
     </tr>

--- a/_pages/en_US/device-selection/iphone-ipod/firmware-selection-(ipod-touch-6).md
+++ b/_pages/en_US/device-selection/iphone-ipod/firmware-selection-(ipod-touch-6).md
@@ -59,7 +59,7 @@ Your device version can be found in the Settings application in `General` -> `Ab
       <td><a href="updating-to-12-4-9">Updating to 12.4.9</a></td>
     </tr>
     <tr>
-      <td>10.0.1</td>
+      <td>10.0</td>
       <td>10.3.3</td>
       <td><a href="using-meridian">Using Meridian</a></td>
     </tr>


### PR DESCRIPTION
Something I found recently was that, while yes, it is true that 10.0 wasn't properly usable on current devices at the time (due to Recovery Mode Loop upon updating) There were _some_ devices that possibly came with iOS 10.0 as the factory firmware.

Note that only the iPhone 7 line has been proven to have had this version, however, other devices were being sold at the same time as the iPhone 7 was announced, this would probably mean that iOS 10.0 was the factory firmware for more devices.

Note as well, that 10.0 doesn't support every jailbreak that supports 10.0.1, that being said Meridian is supported on 10.0 so nothing needs to be changed specifically for 10.0 users unless we ever plan on switching the jailbreak linked for 10.x (which I doubt we plan to do).

With that in mind, there are some devices that need to be mentioned that are in this PR but were in the refurbished tab at the time of iOS 10's launch.

This includes the:
- iPad Air (1st Generation) (A7)
- iPad Mini (3rd Generation) (A7)

Those devices are the only devices which I'm thinking could be question marks in regards to whether or not they _possibly_ could've had 10.0 as the factory firmware or the firmware installed upon the device being refurbished.