### PR TITLE
Fix a series of typos/issues present throughout the guide.

### DIFF
--- a/_pages/en_US/device-selection/iphone-ipod/firmware-selection-iphone-a12.md
+++ b/_pages/en_US/device-selection/iphone-ipod/firmware-selection-iphone-a12.md
@@ -4,7 +4,7 @@
 
 Different firmware versions will require different steps to jailbreak your iOS device. This page will help you find where to start.
 
-Select the appropriate page for your version from the chart below. Note that the "from" and "to" fields are inclusive. This means that, for example, the "from 12.0 to 12.2" row includes version 12.0, version 12.2, and all versions in-between.
+Select the appropriate page for your version from the chart below. Note that the "from" and "to" fields are inclusive. This means that, for example, the "from 12.0 to 12.1.2" row includes version 12.0, version 12.1.2, and all versions in-between.
 
 Your device version can be found in the Settings application in `General` -> `About`.
 

--- a/_pages/en_US/device-selection/iphone-ipod/firmware-selection-iphone-a13.md
+++ b/_pages/en_US/device-selection/iphone-ipod/firmware-selection-iphone-a13.md
@@ -4,7 +4,7 @@
 
 Different firmware versions will require different steps to jailbreak your iOS device. This page will help you find where to start.
 
-Select the appropriate page for your version from the chart below. Note that the "from" and "to" fields are inclusive. This means that, for example, the "from 13.0 to  13.5}" row includes version 13.0, version  13.5, and all versions in-between.
+Select the appropriate page for your version from the chart below. Note that the "from" and "to" fields are inclusive. This means that, for example, the "from 13.0 to  13.7" row includes version 13.0, version  13.7, and all versions in-between.
 
 Your device version can be found in the Settings application in `General` -> `About`.
 

--- a/_pages/en_US/device-selection/iphone-ipod/firmware-selection-iphone-a14.md
+++ b/_pages/en_US/device-selection/iphone-ipod/firmware-selection-iphone-a14.md
@@ -4,7 +4,7 @@
 
 Different firmware versions will require different steps to jailbreak your iOS device. This page will help you find where to start.
 
-Select the appropriate page for your version from the chart below. Note that the "from" and "to" fields are inclusive. This means that, for example, the "from 14.0 to 14.2.1" row includes version 14.0, version 14.2.1, and all versions in-between.
+Select the appropriate page for your version from the chart below. Note that the "from" and "to" fields are inclusive. This means that, for example, the "from 14.0 to 14.3" row includes version 14.0, version 14.3, and all versions in-between.
 
 Your device version can be found in the Settings application in `General` -> `About`.
 
@@ -26,7 +26,7 @@ Your device version can be found in the Settings application in `General` -> `Ab
   <tbody>
     <tr>
       <td>14.0</td>
-      <td>14.2.1</td>
+      <td>{% include latestfw %}</td>
       <td colspan="2">--</td>
     </tr>
 

--- a/_pages/en_US/jailbreak/installing-odyssey.md
+++ b/_pages/en_US/jailbreak/installing-odyssey.md
@@ -24,7 +24,7 @@ We will use AltStore to install the Odyssey jailbreak application to your iOS de
 - The latest version of [Odyssey](https://theodyssey.dev/)
 - The latest version of [AltStore](http://altstore.io/)
 - The latest version of [iTunes](https://www.apple.com/itunes/download/win32) if on Windows
-- The lastet version of [iCloud](https://secure-appldnld.apple.com/windows/061-91601-20200323-974a39d0-41fc-4761-b571-318b7d9205ed/iCloudSetup.exe) if on Windows
+- The latest version of [iCloud](https://secure-appldnld.apple.com/windows/061-91601-20200323-974a39d0-41fc-4761-b571-318b7d9205ed/iCloudSetup.exe) if on Windows
 
 ## Installing the application
 

--- a/_pages/en_US/jailbreak/installing-unc0ver.md
+++ b/_pages/en_US/jailbreak/installing-unc0ver.md
@@ -12,10 +12,13 @@ excerpt: Guide to installing unc0ver
 
 {% include toc title="Table of Contents" %}
 
+Unless you are using an A12 device on iOS 12.1.3 - 12.4.1, you should not be following this page due to the fact that, throughout the past several months, better options have emerged for all other devices/versions, which are listed on each devices page at [Get Started](get-started)
+{:.notice--danger}
+
 unc0ver is a [semi-untethered jailbreak](/types-of-jailbreak#semi-untethered-jailbreaks){:target="_blank"}, meaning it requires a app to re-apply the exploit after a reboot. Click the link to learn more.
 {:.notice--info}
 
-unc0ver is capable of jailbreaking nearly every iOS device on firmware version 11.0 up to 13.5, excluding 12.3 - 12.3.2 and 12.4.2 - 12.4.7.
+unc0ver is capable of jailbreaking every iOS device on firmware version 11.0 up to 13.5, excluding 12.4.9 - 12.5.1.
 
 Due to how [semi-untethered jailbreaks](/types-of-jailbreak#semi-untethered-jailbreaks){:target="_blank"} work, the app will need to be [re-signed](resigning-apps) once every 7 days.
 
@@ -26,7 +29,7 @@ We will use the AltStore tool to install the unc0ver jailbreak application to yo
 - The latest version of [unc0ver](https://github.com/pwn20wndstuff/Undecimus/releases)
 - The latest version of [AltStore](http://altstore.io/)
 - The latest version of [iTunes](https://www.apple.com/itunes/download/win32) if on Windows
-- The leastest version of [iCloud](https://secure-appldnld.apple.com/windows/061-91601-20200323-974a39d0-41fc-4761-b571-318b7d9205ed/iCloudSetup.exe) if on Windows
+- The latest version of [iCloud](https://secure-appldnld.apple.com/windows/061-91601-20200323-974a39d0-41fc-4761-b571-318b7d9205ed/iCloudSetup.exe) if on Windows
 
 ## Installing the application
 

--- a/_pages/en_US/updating-to-10.3.3.md
+++ b/_pages/en_US/updating-to-10.3.3.md
@@ -9,7 +9,7 @@ permalink: /updating-to-10-3-3
 
 Unfortunately, there is currently no jailbreak available for firmware versions 8.4.1 or 9.3.4 to 9.3.5 on 64-bit devices. However devices, such as the iPhone 5S, can update to 10.3.3 and use the Meridian jailbreak instead.
 
-This is achieved by simply updating through the Settings application normally. Because the latest available OTA version for their current firmware on these devices is 10.3.3, we can easily update to the desired firmware version, due to the age of their curremt firmware version.
+This is achieved by simply updating through the Settings application normally. Because the latest available OTA version for their current firmware on these devices is 10.3.3, we can easily update to the desired firmware version, due to the age of their current firmware version.
 
 If you have installed update blocking via tvOS Beta profiles, you must first remove that profile before updating. If you don't know what this means, ignore this.
 

--- a/_pages/en_US/updating-to-14.3.md
+++ b/_pages/en_US/updating-to-14.3.md
@@ -7,7 +7,7 @@ redirect_from:
 
 {% include toc title="Table of Contents" %}
 
-Take caution with updating as checkra1n only supports A8(X) and A9(X) on iOS 14.3 at this time. A10(X) is only supported on iOS 14.0 - 14.2.
+Take caution with updating as checkra1n only supports A8(X) to A10(X) on iOS 14.3 at this time.
 
 ## Required Reading
 

--- a/_pages/en_US/updating-to-6.1.3.md
+++ b/_pages/en_US/updating-to-6.1.3.md
@@ -9,7 +9,7 @@ permalink: /updating-to-6-1-3
 
 Unfortunately, there is currently no jailbreak available for firmware versions 5.0 or 5.1 to on most A5 devices. However devices, such as the iPhone 4S, can update to 6.1.3 and use p0sixspwn instead.
 
-This is achieved by simply updating through the Settings application normally. Because the latest available OTA version for their current firmware on these devices is 6.1.3, we can easily update to the desired firmware version, due to the age of their curremt firmware version.
+This is achieved by simply updating through the Settings application normally. Because the latest available OTA version for their current firmware on these devices is 6.1.3, we can easily update to the desired firmware version, due to the age of their current firmware version.
 
 If you have installed update blocking via tvOS Beta profiles, you must first remove that profile before updating. If you don't know what this means, ignore this.
 


### PR DESCRIPTION
This PR accomplishes two different goals here:
- Solves a varying amount of typos across several pages on the guide
- Adds a notice to the u0 page, discouraging users from using u0 due to better options being present except under the specific circumstances u0 is still required for.