### PR TITLE
Pull Request before the Massive Pull Request that's gonna be massive in size but not quantity anyways

### DIFF
--- a/_pages/en_US/jailbreak/installing-unc0ver.md
+++ b/_pages/en_US/jailbreak/installing-unc0ver.md
@@ -12,7 +12,7 @@ excerpt: Guide to installing unc0ver
 
 {% include toc title="Table of Contents" %}
 
-Unless you are using an A12 device on iOS 12.1.3 - 12.4.1, you should not be following this page due to the fact that, throughout the past several months, better options have emerged for all other devices/versions, which have superseded unc0ver to the extent where the guide is only recommended and will only contain references to the applicable devices/versions, which are listed on each devices page at [Get Started](get-started)
+Unless you are using an A12 device on iOS 12.1.3 - 12.4.1, you **should not** be following this page. Better options are now available for most devices/versions, which have superseded unc0ver to the extent where the guide is only recommended and will only contain references to the applicable devices/versions, which are listed on each devices page at [Get Started](get-started).
 {:.notice--danger}
 
 unc0ver is a [semi-untethered jailbreak](/types-of-jailbreak#semi-untethered-jailbreaks){:target="_blank"}, meaning it requires a app to re-apply the exploit after a reboot. Click the link to learn more.

--- a/_pages/en_US/jailbreak/installing-unc0ver.md
+++ b/_pages/en_US/jailbreak/installing-unc0ver.md
@@ -12,13 +12,13 @@ excerpt: Guide to installing unc0ver
 
 {% include toc title="Table of Contents" %}
 
-Unless you are using an A12 device on iOS 12.1.3 - 12.4.1, you should not be following this page due to the fact that, throughout the past several months, better options have emerged for all other devices/versions, which are listed on each devices page at [Get Started](get-started)
+Unless you are using an A12 device on iOS 12.1.3 - 12.4.1, you should not be following this page due to the fact that, throughout the past several months, better options have emerged for all other devices/versions, which have superseded unc0ver to the extent where the guide is only recommended and will only contain references to the applicable devices/versions, which are listed on each devices page at [Get Started](get-started)
 {:.notice--danger}
 
 unc0ver is a [semi-untethered jailbreak](/types-of-jailbreak#semi-untethered-jailbreaks){:target="_blank"}, meaning it requires a app to re-apply the exploit after a reboot. Click the link to learn more.
 {:.notice--info}
 
-unc0ver is capable of jailbreaking every iOS device on firmware version 11.0 up to 13.5, excluding 12.4.9 - 12.5.1.
+unc0ver is capable of jailbreaking every iOS device on firmware version 11.0 up to 13.5, excluding 12.4.9 - 12.5.1, however, for our purposes, it will be used to jailbreak A12 devices on 12.1.3 - 12.4.1.
 
 Due to how [semi-untethered jailbreaks](/types-of-jailbreak#semi-untethered-jailbreaks){:target="_blank"} work, the app will need to be [re-signed](resigning-apps) once every 7 days.
 
@@ -31,7 +31,7 @@ We will use the AltStore tool to install the unc0ver jailbreak application to yo
 - The latest version of [iTunes](https://www.apple.com/itunes/download/win32) if on Windows
 - The latest version of [iCloud](https://secure-appldnld.apple.com/windows/061-91601-20200323-974a39d0-41fc-4761-b571-318b7d9205ed/iCloudSetup.exe) if on Windows
 
-If you are running iOS 12.0 - 12.1.4, you will need to use [AltDeploy](resigning-apps#resign-with-a-mac-altdeploy)
+If you are running iOS 12.1.3 - 12.1.4, you will need to use [AltDeploy](resigning-apps#resign-with-a-mac-altdeploy)
 {: .notice--info}
 
 ## Installing the application


### PR DESCRIPTION
I decided to PR this in before I went ahead with the massive PR incoming, seeing as I do feel it would make more sense to PR this thing initially, before other changes are completed.

I also decided to write the below up, mainly because of the fact that other users may see this and wonder why we are progressing with this process, **note not everything stated below is final, but this is the perceived plan moving forward**.

**Statement on unc0ver and the planned future of this page** (for people who are interested in reading the general future plans)

The long term plan is currently to maintain this page on the guide until better options come out, but to gear users who **do not require unc0ver** away from this guide and instead look at better options. The first part of this goal was completed with the introduction of the text along the lines of "**Unless you're on an A12 device on 12.1.3 - 12.4.1, you should not be following this guide.**" in #26 

This PR brings along the second part of this process, with us further detailing guidance (indirectly explaining that this guide will be obsoleted/EOL'd the moment a better option is made), as well as changing the guide to only focus on the devices/versions unc0ver is absolutely required for. This is currently the last part of this process for the foreseeable future, and we will maintain the guide until better options come out.

Note however, that upon a new method (e.g. an Odyssey backport) being made/released, this guide will be removed from both visibility and site navigation, and eventually, will be auto-redirected to https://ios.cfw.guide/get-started, both of these actions will EOL this method (and for good reason)

Now, **Why do we wish to EOL unc0ver?** For many reasons:

1. unc0ver has not received or has had true maintaining of any remote sorts ever since mid-July
2. The consistent usage of old, outdated things, that are generally worse for newer users to deal with (e.g. Substitute, Cydia, and sbingner bootstrap)
3. unc0ver and their dev's general bad practices (false DMCA'ing Chimera13/Odyssey, stopped open sourcing unc0ver for no direct reason, etc.)
4. The fact that users have had continuous issues that only stopped when switching jailbreaks (e.g. from unc0ver to Odyssey)
5. The fact that, if users aren't careful, a particular set of steps can be taking where they completely break OTA updates, and then updating using iTunes to a later version which doesn't support unc0ver, which can only be resolved by a DFU restore without restoring from a backup

And, the biggest reason of all: why maintain/not EOL something when better options exist?
The answer: there is no reason to.

**The only thing keeping us from EOL'ing unc0ver from the guide is A12 12.1.3-12.4.1, once a better option comes out, unc0ver is going to be EOL'd.**

(sorry @emiyl for adding this tangent at the end)