### PR TITLE
Mega PR (Part One)

### DIFF
--- a/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-8).md
+++ b/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-8).md
@@ -35,6 +35,11 @@ Your device version can be found in the Settings application in `General` -> `Ab
   <tbody>
     <tr>
       <td>14.0</td>
+      <td>14.3</td>
+      <td colspan="2">Coming Soon</td>
+     </tr>
+    <tr>
+      <td>{% include latestfw %}</td>
       <td>{% include latestfw %}</td>
       <td colspan="2">--</td>
      </tr>

--- a/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-air-3).md
+++ b/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-air-3).md
@@ -45,10 +45,14 @@ Your device version can be found in the Settings application in `General` -> `Ab
     </tr>
     <tr>
       <td>14.0</td>
+      <td>14.3</td>
+      <td colspan="2">Coming Soon</td>
+     </tr>
+	<tr>
+      <td>{% include latestfw %}</td>
       <td>{% include latestfw %}</td>
       <td colspan="2">--</td>
      </tr>
-
   </tbody>
 </table>
 

--- a/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-air-4).md
+++ b/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-air-4).md
@@ -35,10 +35,14 @@ Your device version can be found in the Settings application in `General` -> `Ab
   <tbody>
     <tr>
       <td>14.0</td>
+      <td>14.3</td>
+      <td colspan="2">Coming Soon</td>
+     </tr>
+	<tr>
+      <td>{% include latestfw %}</td>
       <td>{% include latestfw %}</td>
       <td colspan="2">--</td>
      </tr>
-
   </tbody>
 </table>
 

--- a/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-mini-5).md
+++ b/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-mini-5).md
@@ -45,10 +45,14 @@ Your device version can be found in the Settings application in `General` -> `Ab
     </tr>
     <tr>
       <td>14.0</td>
+      <td>14.3</td>
+      <td colspan="2">Coming Soon</td>
+     </tr>
+	<tr>
+      <td>{% include latestfw %}</td>
       <td>{% include latestfw %}</td>
       <td colspan="2">--</td>
      </tr>
-
   </tbody>
 </table>
 

--- a/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-pro-3).md
+++ b/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-pro-3).md
@@ -35,7 +35,7 @@ Your device version can be found in the Settings application in `General` -> `Ab
   <tbody>
     <tr>
       <td>12.1</td>
-      <td>12.1.1</td>
+      <td>12.1.2</td>
       <td><a href="installing-chimera">Installing Chimera</a></td>
     </tr>
     <tr>
@@ -50,10 +50,14 @@ Your device version can be found in the Settings application in `General` -> `Ab
     </tr>
     <tr>
       <td>14.0</td>
+      <td>14.3</td>
+      <td colspan="2">Coming Soon</td>
+     </tr>
+	<tr>
+      <td>{% include latestfw %}</td>
       <td>{% include latestfw %}</td>
       <td colspan="2">--</td>
      </tr>
-
   </tbody>
 </table>
 

--- a/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-pro-4).md
+++ b/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-pro-4).md
@@ -40,6 +40,11 @@ Your device version can be found in the Settings application in `General` -> `Ab
     </tr>
     <tr>
       <td>14.0</td>
+      <td>14.3</td>
+      <td colspan="2">Coming Soon</td>
+     </tr>
+	<tr>
+      <td>{% include latestfw %}</td>
       <td>{% include latestfw %}</td>
       <td colspan="2">--</td>
      </tr>

--- a/_pages/en_US/device-selection/iphone-ipod/firmware-selection-(iphone-12).md
+++ b/_pages/en_US/device-selection/iphone-ipod/firmware-selection-(iphone-12).md
@@ -3,7 +3,7 @@ title: Firmware Selection (iPhone 12)
 permalink: /firmware-selection-(iphone-12)
 redirect_from:
   - /iphone-12
-excerpt: Find out what jailbreaks you can use on your iPhone 12 or iPhone 12 mini
+excerpt: Find out what jailbreaks you can use on your iPhone 12
 soc: A14 Bionic
 ---
 

--- a/_pages/en_US/device-selection/iphone-ipod/firmware-selection-(iphone-se-2).md
+++ b/_pages/en_US/device-selection/iphone-ipod/firmware-selection-(iphone-se-2).md
@@ -41,10 +41,14 @@ Your device version can be found in the Settings application in `General` -> `Ab
     </tr>
     <tr>
       <td>14.0</td>
+      <td>14.3</td>
+      <td colspan="2">Coming Soon</td>
+     </tr>
+	<tr>
+      <td>{% include latestfw %}</td>
       <td>{% include latestfw %}</td>
       <td colspan="2">--</td>
-    </tr>
-
+     </tr>
   </tbody>
 </table>
 

--- a/_pages/en_US/device-selection/iphone-ipod/firmware-selection-iphone-a11.md
+++ b/_pages/en_US/device-selection/iphone-ipod/firmware-selection-iphone-a11.md
@@ -41,9 +41,14 @@ Your device version can be found in the Settings application in `General` -> `Ab
     </tr>
      <tr>
       <td>14.0</td>
+      <td>14.3</td>
+      <td colspan="2">Coming Soon</td>
+     </tr>
+	<tr>
       <td>{% include latestfw %}</td>
-      <td>--</td>
-      </tr>
+      <td>{% include latestfw %}</td>
+      <td colspan="2">--</td>
+     </tr>
   </tbody>
 </table>
 

--- a/_pages/en_US/device-selection/iphone-ipod/firmware-selection-iphone-a12.md
+++ b/_pages/en_US/device-selection/iphone-ipod/firmware-selection-iphone-a12.md
@@ -41,10 +41,14 @@ Your device version can be found in the Settings application in `General` -> `Ab
     </tr>
     <tr>
       <td>14.0</td>
+      <td>14.3</td>
+      <td colspan="2">Coming Soon</td>
+     </tr>
+	<tr>
+      <td>{% include latestfw %}</td>
       <td>{% include latestfw %}</td>
       <td colspan="2">--</td>
      </tr>
-
   </tbody>
 </table>
 

--- a/_pages/en_US/device-selection/iphone-ipod/firmware-selection-iphone-a14.md
+++ b/_pages/en_US/device-selection/iphone-ipod/firmware-selection-iphone-a14.md
@@ -24,12 +24,16 @@ Your device version can be found in the Settings application in `General` -> `Ab
     </tr>
   </thead>
   <tbody>
-    <tr>
+   <tr>
       <td>14.0</td>
+      <td>14.3</td>
+      <td colspan="2">Coming Soon</td>
+     </tr>
+	<tr>
+      <td>{% include latestfw %}</td>
       <td>{% include latestfw %}</td>
       <td colspan="2">--</td>
-    </tr>
-
+     </tr>
   </tbody>
 </table>
 

--- a/_pages/en_US/jailbreak-types.md
+++ b/_pages/en_US/jailbreak-types.md
@@ -43,11 +43,11 @@ Semi-untethered jailbreaks have been the most popular type of jailbreak in recen
 
 <img src="{{ "/assets/images/odysseymain.png" | absolute_url }}" width="250" class="align-right"/>
 
-This jailbreak works by running the exploit through an app on the device itself. The app, however, must be resigned every 7 days if sideloaded with a standard Apple ID. Utilities like AltStore and ReProvision make this process far easier.
+This jailbreak works by running the exploit through an app on the device itself. The app, however, must be resigned every 7 days if sideloaded with a standard Apple ID. Utilities like AltStore, ReProvisionFix, and AltDaemon make this process far easier.
 
 Due to the nature of how the exploit is applied, these jailbreaks are easily removable through their respective app.
 
-A few examples of semi-untethered jailbreaks include [Odyssey](installing-odyssey), [Chimera](installing-chimera), [Electra](installing-electra), and [unc0ver](installing-unc0ver).
+A few examples of semi-untethered jailbreaks include [Odyssey](installing-odyssey), [Chimera](installing-chimera), and [Electra](installing-electra).
 
 ### Semi-Tethered Jailbreaks
 ---
@@ -58,7 +58,7 @@ Semi-tethered jailbreaks are very similar to semi-unthered jailbreaks, however t
 
 Due to requiring a computer to rejailbreak after every reboot, most choose to use a semi-untethered jailbreak instead.
 
-An example of a semi-tethered jailbreak is [checkra1n](installing-checkra1n).
+An example of a semi-tethered jailbreak is [Odysseyra1n](installing-odysseyra1n).
 
 ### Tethered Jailbreaks
 ---

--- a/_pages/en_US/jailbreak/installing-chimera.md
+++ b/_pages/en_US/jailbreak/installing-chimera.md
@@ -59,12 +59,14 @@ The Chimera application can now be opened from home screen.
 1. Open the Chimera application from your home screen immediately afterwards
 1. Tap "Jailbreak"
 1. Reboot your phone again when prompted
+  - If you are not prompted and it automatically reboots, wait 1-2 minutes, then try again.
   - This time, it is necessary
 1. Once again, open the Chimera application from your home screen immediately after rebooting
 1. Tap "Jailbreak" again
+  - If it automatically reboots or crashes and the jailbreak is not installed, wait 1-2 minutes, then try again.
 
-If that app or your device crashes/restarts unexpectedly and the jailbreak isn't installed, simply try rebooting and running the exploit again until it does work.
-{:.notice--danger}
+If that app or your device continually crashes/restarts unexpectedly and the jailbreak isn't installed despite the above steps, attempt to put the device in a freezer for that 1-2 minute period.
+{:.notice--info}
 
 You should now be jailbroken with Sileo installed on your home screen. You can use Sileo to install [tweaks](faq#tweaks), themes and more.
 

--- a/_pages/en_US/jailbreak/using-cydia.md
+++ b/_pages/en_US/jailbreak/using-cydia.md
@@ -10,7 +10,7 @@ excerpt: Guide to using Cydia
 
 ## Introduction
 
-Cydia is incredibly outdated. If you are using Electra, Chimera, Odyssey, or Checkra1n, please consider using [Sileo](sileo){:target="_blank"}
+Cydia is incredibly outdated. If you are using Electra, Chimera, Odyssey, or Odysseyra1n, please consider using [Sileo](sileo){:target="_blank"}
 {: .notice--info}
 
 Cydia is a package manager that has been used since the start of jailbreaking in 2008. It can be used to install tweaks and themes.
@@ -43,7 +43,7 @@ You can now enter the repo from this page to see all the tweaks available on it.
 1. Tap the red icon next to the repo you want to delete
 1. Confirm the deletion
 
-The repo should now be removed from Sileo.
+The repo should now be removed from Cydia.
 {:.notice--textbox}
 
 ## Installing Tweaks

--- a/_pages/en_US/misc/credits.md
+++ b/_pages/en_US/misc/credits.md
@@ -60,7 +60,7 @@ If I forgot you here, contact me and I'll add your name.
   + patricck88
   + pharzyn
   + Kabir Oberai
-  + TheMasterOfMike
+  + MasterOfMike
   + Aspen
   + Steckler (atoiletcat)
   + Cimmerian_Iter

--- a/_pages/en_US/package-managers.md
+++ b/_pages/en_US/package-managers.md
@@ -14,25 +14,26 @@ After jailbreaking, you may be wondering what a package manager is, and why it's
 
 Package managers are in some ways like an App Store for tweaks. They allow you to browse repositories (sometimes referred to as repos or sources) and download tweaks, apps, and other pieces of software for your jailbroken device. Most jailbreaks come pre-packaged with a package manager called Cydia.
 
+### Sileo
+
+{% capture sileo %}
+Sileo is a relatively new Package Manager made by [Coolstar](https://twitter.com/CStar_OW). It's used to download and install jailbreak tweaks, similar to package managers listed below. Sileo prides itself with its superior performance, modern design, and general QOL improvements.
+
+Sileo is only available using Electra, Chimera, Odyssey, and Odysseyra1n.
+{% endcapture %}
+
+<div class="notice--info">{{ sileo | markdownify }}</div>
+
+
 ### Cydia
 
 {% capture cydia %}
 Cydia has been around almost as long as jailbreaking iOS devices has. It's the package manager that's historically been at the front of every jailbreak, however has since been abandoned by its creator. Due to it's age, it unfortunately suffers from its outdated design and slow performance.
 
-Cydia, while not recommended, is available using the unc0ver, checkra1n, and other older jailbreaks. You can also choose to install it on Odyssey and Chimera if you so wish to.
+Cydia, while not recommended, is available using unc0ver and other older jailbreaks. You can also choose to install it on Odyssey or Chimera if you so wish to.
 {% endcapture %}
 
 <div class="notice--info">{{ cydia | markdownify }}</div>
-
-### Sileo
-
-{% capture sileo %}
-Sileo is a relatively new Package Manager made by [Coolstar](https://twitter.com/CStar_OW). Just like Cydia, it's used to download and install jailbreak tweaks. Sileo prides itself with its superior performance, modern design, and general QOL improvements.
-
-Sileo is only available using the Electra, Chimera and Odyssey jailbreaks.
-{% endcapture %}
-
-<div class="notice--info">{{ sileo | markdownify }}</div>
 
 ### Installer 5
 

--- a/_pages/en_US/updating-to-12.5.1.md
+++ b/_pages/en_US/updating-to-12.5.1.md
@@ -10,7 +10,7 @@ redirect_from:
 
 ## Required Reading
 
-Checkra1n and Chimera are both compatible with the latest signed version of iOS, 12.5.1, for A7/A8.
+Odysseyra1n and Chimera are both compatible with the latest signed version of iOS, 12.5.1, for A7 and most A8 devices.
 {: .notice--primary}
 
 If you have installed update blocking via tvOS Beta profiles, you must first remove that profile before updating. If you don't know what this means, ignore this.


### PR DESCRIPTION
This part of the Massive Pull Request does the following:
- Changes 14.0-14.3 of tables which do not have a jailbreak on 14.x to have 'Coming Soon' text
- Adds/Alters some information on the Installing Chimera page to include information which increases success rates significantly (mainly for users who have to use life_waste)
- Swaps around the Sileo/Cydia placement in the package manager page to signify that Sileo is the preferred package manager for modern jailbreaks
- Typo/Wording fixes/changes across certain pages
- Updates my credits name to my new discord name

Changes planned for Part Two of this Mega PR include (but are not limited to):
- Troubleshooting page Rewrite
- FAQ cleanup (and possible rewrite in some areas)
- Possible new Saving Blobs guide
- Possible new Futurerestore guide
- Probably more typo/wording changes/fixes across more pages