### PR TITLE
14.5 is *fun* (aka garbage)

### DIFF
--- a/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-5).md
+++ b/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-5).md
@@ -62,14 +62,9 @@ Your device version can be found in the Settings application in `General` -> `Ab
     </tr>
     <tr>
       <td>14.4</td>
-      <td>14.4.2</td>
+      <td>{% include latestfw %}</td>
       <td><a href="installing-odysseyra1n">Installing Odysseyra1n</a></td>
       <td><a href="using-odysseyn1x">Using Odysseyn1x</a></td>
-    </tr>
-    <tr>
-      <td>{% include latestfw %}</td>
-      <td>{% include latestfw %}</td>
-      <td colspan="2">--</td>
     </tr>
   </tbody>
 </table>

--- a/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-6).md
+++ b/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-6).md
@@ -57,14 +57,9 @@ Your device version can be found in the Settings application in `General` -> `Ab
     </tr>
     <tr>
       <td>14.4</td>
-      <td>14.4.2</td>
+      <td>{% include latestfw %}</td>
       <td><a href="installing-odysseyra1n">Installing Odysseyra1n</a></td>
       <td><a href="using-odysseyn1x">Using Odysseyn1x</a></td>
-    </tr>
-    <tr>
-      <td>{% include latestfw %}</td>
-      <td>{% include latestfw %}</td>
-      <td colspan="2">--</td>
     </tr>
   </tbody>
 </table>

--- a/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-7).md
+++ b/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-7).md
@@ -44,17 +44,12 @@ Your device version can be found in the Settings application in `General` -> `Ab
       <td>14.0</td>
       <td>14.3</td>
       <td colspan="2"><a href="installing-taurine">Installing Taurine</a></td>
-     </tr>
-     <tr>
-      <td>14.4</td>
-      <td>14.4.2</td>
-      <td><a href="installing-odysseyra1n">Installing Odysseyra1n</a></td>
-      <td><a href="using-odysseyn1x">Using Odysseyn1x</a></td>
     </tr>
     <tr>
+      <td>14.4</td>
       <td>{% include latestfw %}</td>
-      <td>{% include latestfw %}</td>
-      <td colspan="2">--</td>
+      <td><a href="installing-odysseyra1n">Installing Odysseyra1n</a></td>
+      <td><a href="using-odysseyn1x">Using Odysseyn1x</a></td>
     </tr>
   </tbody>
 </table>

--- a/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-air).md
+++ b/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-air).md
@@ -43,7 +43,7 @@ Your device version can be found in the Settings application in `General` -> `Ab
     <tr>
       <td>8.4.1</td>
       <td>8.4.1</td>
-      <td><a href="updating-to-12-5-2">Updating to 12.5.2</a></td>
+      <td><a href="updating-to-10-3-3">Updating to 10.3.3</a></td>
     </tr>
     <tr>
       <td>9.0</td>

--- a/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-air-2).md
+++ b/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-air-2).md
@@ -87,14 +87,9 @@ Your device version can be found in the Settings application in `General` -> `Ab
     </tr>
     <tr>
       <td>14.4</td>
-      <td>14.4.2</td>
+      <td>{% include latestfw %}</td>
       <td><a href="installing-odysseyra1n">Installing Odysseyra1n</a></td>
       <td><a href="using-odysseyn1x">Using Odysseyn1x</a></td>
-    </tr>
-    <tr>
-      <td>{% include latestfw %}</td>
-      <td>{% include latestfw %}</td>
-      <td colspan="2">--</td>
     </tr>
   </tbody>
 </table>

--- a/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-mini-4).md
+++ b/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-mini-4).md
@@ -77,14 +77,9 @@ Your device version can be found in the Settings application in `General` -> `Ab
     </tr>
     <tr>
       <td>14.4</td>
-      <td>14.4.2</td>
+      <td>{% include latestfw %}</td>
       <td><a href="installing-odysseyra1n">Installing Odysseyra1n</a></td>
       <td><a href="using-odysseyn1x">Using Odysseyn1x</a></td>
-    </tr>
-    <tr>
-      <td>{% include latestfw %}</td>
-      <td>{% include latestfw %}</td>
-      <td colspan="2">--</td>
     </tr>
   </tbody>
 </table>

--- a/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-pro).md
+++ b/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-pro).md
@@ -78,14 +78,9 @@ Your device version can be found in the Settings application in `General` -> `Ab
      </tr>
     <tr>
       <td>14.4</td>
-      <td>14.4.2</td>
+      <td>{% include latestfw %}</td>
       <td><a href="installing-odysseyra1n">Installing Odysseyra1n</a></td>
       <td><a href="using-odysseyn1x">Using Odysseyn1x</a></td>
-    </tr>
-    <tr>
-      <td>{% include latestfw %}</td>
-      <td>{% include latestfw %}</td>
-      <td colspan="2">--</td>
     </tr>
   </tbody>
 </table>

--- a/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-pro-2).md
+++ b/_pages/en_US/device-selection/ipad/firmware-selection-(ipad-pro-2).md
@@ -62,14 +62,9 @@ Your device version can be found in the Settings application in `General` -> `Ab
     </tr>
     <tr>
       <td>14.4</td>
-      <td>14.4.2</td>
+      <td>{% include latestfw %}</td>
       <td><a href="installing-odysseyra1n">Installing Odysseyra1n</a></td>
       <td><a href="using-odysseyn1x">Using Odysseyn1x</a></td>
-    </tr>
-    <tr>
-      <td>{% include latestfw %}</td>
-      <td>{% include latestfw %}</td>
-      <td colspan="2">--</td>
     </tr>
   </tbody>
 </table>

--- a/_pages/en_US/device-selection/iphone-ipod/firmware-selection-(iphone-6s).md
+++ b/_pages/en_US/device-selection/iphone-ipod/firmware-selection-(iphone-6s).md
@@ -77,14 +77,9 @@ Your device version can be found in the Settings application in `General` -> `Ab
     </tr>
     <tr>
       <td>14.4</td>
-      <td>14.4.2</td>
+      <td>{% include latestfw %}</td>
       <td><a href="installing-odysseyra1n">Installing Odysseyra1n</a></td>
       <td><a href="using-odysseyn1x">Using Odysseyn1x</a></td>
-    </tr>
-    <tr>
-      <td>{% include latestfw %}</td>
-      <td>{% include latestfw %}</td>
-      <td colspan="2">--</td>
     </tr>
   </tbody>
 </table>

--- a/_pages/en_US/device-selection/iphone-ipod/firmware-selection-(iphone-7).md
+++ b/_pages/en_US/device-selection/iphone-ipod/firmware-selection-(iphone-7).md
@@ -62,14 +62,9 @@ Your device version can be found in the Settings application in `General` -> `Ab
     </tr>
     <tr>
       <td>14.4</td>
-      <td>14.4.2</td>
+      <td>{% include latestfw %}</td>
       <td><a href="installing-odysseyra1n">Installing Odysseyra1n</a></td>
       <td><a href="using-odysseyn1x">Using Odysseyn1x</a></td>
-    </tr>
-    <tr>
-      <td>{% include latestfw %}</td>
-      <td>{% include latestfw %}</td>
-      <td colspan="2">--</td>
     </tr>
   </tbody>
 </table>

--- a/_pages/en_US/device-selection/iphone-ipod/firmware-selection-(iphone-se).md
+++ b/_pages/en_US/device-selection/iphone-ipod/firmware-selection-(iphone-se).md
@@ -72,14 +72,9 @@ Your device version can be found in the Settings application in `General` -> `Ab
     </tr>
     <tr>
       <td>14.4</td>
-      <td>14.4.2</td>
+      <td>{% include latestfw %}</td>
       <td><a href="installing-odysseyra1n">Installing Odysseyra1n</a></td>
       <td><a href="using-odysseyn1x">Using Odysseyn1x</a></td>
-    </tr>
-    <tr>
-      <td>{% include latestfw %}</td>
-      <td>{% include latestfw %}</td>
-      <td colspan="2">--</td>
     </tr>
   </tbody>
 </table>

--- a/_pages/en_US/device-selection/iphone-ipod/firmware-selection-(ipod-touch-7).md
+++ b/_pages/en_US/device-selection/iphone-ipod/firmware-selection-(ipod-touch-7).md
@@ -52,14 +52,9 @@ Your device version can be found in the Settings application in `General` -> `Ab
     </tr>
     <tr>
       <td>14.4</td>
-      <td>14.4.2</td>
+      <td>{% include latestfw %}</td>
       <td><a href="installing-odysseyra1n">Installing Odysseyra1n</a></td>
       <td><a href="using-odysseyn1x">Using Odysseyn1x</a></td>
-    </tr>
-    <tr>
-      <td>{% include latestfw %}</td>
-      <td>{% include latestfw %}</td>
-      <td colspan="2">--</td>
     </tr>
   </tbody>
 </table>

--- a/_pages/en_US/jailbreak/checkra1n/installing-odysseyra1n.md
+++ b/_pages/en_US/jailbreak/checkra1n/installing-odysseyra1n.md
@@ -22,7 +22,7 @@ You are currently not running a macOS or Linux device and this guide will not wo
 
 <script src="/assets/js/hide.js"></script>
 
-On iOS 14.0 to 14.4.2, Odysseyra1n is only fully supported on A8(X) to A10(X) devices for the moment. Full A11 support may be added at future date.
+On iOS 14.0 to {% include latestfw %} Odysseyra1n is only fully supported on A8(X) to A10(X) devices for the moment. Full A11 support may be added at future date.
 {: .notice--info}
 
 {% include_relative include/semi-tethered.md %}
@@ -34,7 +34,7 @@ checkra1n is a tool capable of jailbreaking millions of iOS device on firmwares 
 If you are using Windows, proceed to [Using odysseyn1x](/using-odysseyn1x).
 {: .notice--primary #hide_os }
 
-If you're migrating from unc0ver to checkra1n, you must follow [Removing unc0ver](removing-unc0ver) before proceeding.
+If you're migrating from unc0ver to Odysseyra1n, you must follow [Removing unc0ver](removing-unc0ver) before proceeding.
 {: .notice--textbox}
 
 Please select your operating system below:

--- a/_pages/en_US/jailbreak/checkra1n/ra1n-linux.md
+++ b/_pages/en_US/jailbreak/checkra1n/ra1n-linux.md
@@ -9,7 +9,6 @@
 1. Run the `checkra1n` binary in the terminal using `./checkra1n`
   - You may need to run `sudo chmod a+x ./checkra1n` if the binary doesn't run
 1. Click `Start` and follow all onscreen prompts
-  - You may need to enable `enable untested versions` if you are on iOS 14.4 to 14.4.2 before being able to follow this step
 1. You will now be presented with instructions in how to reboot your device into [DFU mode](faq#dfu_mode), click `Start` to begin
   - Follow the instructions until your device shows a black screen
 1. After this, checkra1n should automatically install

--- a/_pages/en_US/jailbreak/checkra1n/ra1n-macos.md
+++ b/_pages/en_US/jailbreak/checkra1n/ra1n-macos.md
@@ -1,30 +1,34 @@
 ## Downloads (macOS)
 
 - The latest release of [checkra1n](https://checkra.in)
-- The latest release of [Betelguese](https://github.com/23Aaron/Betelguese/releases/latest)
 
 ![]({{ "/assets/images/checkra1n.png" | absolute_url }})
 
 ## Installing checkra1n
 
+If you're using an M1 Mac and are attempting to jailbreak on A7 or A9X (not A9) to A10(X) devices, you will be prompted during the process to unplug and replug the device and will need to do so.
+{: .notice--info}
+
 1. Open checkra1n on your computer
 1. Plug your iOS device into your computer
 1. Click `Start` -> `Next` on checkra1n
-  - You may need to enable `enable untested versions` if you are on iOS 14.4 to 14.4.2 before being able to follow this step
   - Your device will be put into recovery mode automatically
 1. You will now be presented with instructions in how to reboot your device into [DFU mode](faq#dfu_mode), click `Start` to begin
   - Follow the instructions until your device shows a black screen
 1. After this, checkra1n should automatically install
 
-Your iOS device should now reboot.
+Your iOS device should reboot. Do not open the checkra1n app until you have ran the Odysseyra1n script.
 
-To install Odysseyra1n, do not open the checkra1n app and install Cydia. Instead, follow the following instructions to install Sileo.
-{: .notice--info}
+## The Odysseyra1n script
 
-## Using Betelguese
+1. Open the terminal app on your computer
+1. Ensure that your computer is trusted by your device
+1. Install "homebrew" by pasting and executing the following command:
 
-1. Open the Betelguese app on your computer
-1. Ensure your iOS device is connected to your macOS device
-1. Click the `Install Odysseyra1n` button and wait for it to complete
+    `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"`
+1. Install "iproxy" by pasting and executing the following command:
 
-{% include_relative include/end-of-page.md %}
+    `brew install libusbmuxd`
+1. Install the Odysseyra1n script by pasting and executing the following command:
+
+    `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/coolstar/Odyssey-bootstrap/master/procursus-deploy-linux-macos.sh)"`

--- a/_pages/en_US/jailbreak/checkra1n/using-odysseyn1x.md
+++ b/_pages/en_US/jailbreak/checkra1n/using-odysseyn1x.md
@@ -23,7 +23,7 @@ sidebar:
 
 Odysseyn1x is a live bootable Linux environment that allows you to quickly run checkra1n on a compatible device. checkra1n is capable of jailbreaking millions of iOS device on firmwares 12.0 and above.
 
-On iOS 14.0 to 14.4.2, Odysseyn1x is only fully supported on A8(X) to A10(X) devices for the moment. Full A11 support may be added at future date.
+On iOS 14.0 to {% include latestfw %}, Odysseyn1x is only fully supported on A8(X) to A10(X) devices for the moment. Full A11 support may be added at future date.
 {: .notice--info}
 
 {% include_relative include/odysseyra1n-explanation.md %}
@@ -60,7 +60,6 @@ On iOS 14.0 to 14.4.2, Odysseyn1x is only fully supported on A8(X) to A10(X) dev
 
 1. Once you have loaded odysseyn1x, select `checkra1n`
 1. Click `Start` and follow all onscreen prompts
-  - You may need to enable `enable untested versions` if you are on iOS 14.4 to {% include latestfw %} before being able to follow this step
 1. You will now be presented with instructions in how to reboot your device into [DFU mode](faq#dfu_mode), click `Start` to begin
   - Follow the instructions until your device reboots to a black screen
 1. Once your device boots, you can quit checkra1n, but do not shut down your computer

--- a/_pages/en_US/updating/updating-to-10.3.3.md
+++ b/_pages/en_US/updating/updating-to-10.3.3.md
@@ -5,7 +5,7 @@ permalink: /updating-to-10-3-3
 
 ## Required Reading
 
-Unfortunately, there is currently no jailbreak available for firmware versions 8.4.1 or 9.3.4 to 9.3.5 on 64-bit devices. However devices, such as the iPhone 5S, can update to 10.3.3 and use the Meridian jailbreak instead.
+Unfortunately, there is currently no jailbreak available for firmware version 8.4.1 on 64-bit devices. However devices, such as the iPhone 5S, can update to 10.3.3 and use the Meridian jailbreak instead.
 
 This is achieved by simply updating through the Settings application normally. Because the latest available OTA version for their current firmware on these devices is 10.3.3, we can easily update to the desired firmware version, due to the age of their current firmware version.
 

--- a/_pages/en_US/updating/updating-to-14.5.md
+++ b/_pages/en_US/updating/updating-to-14.5.md
@@ -9,12 +9,12 @@ redirect_from:
   - /updating-to-14-4-2
 ---
 
-There is no jailbreak for iOS 14.5 at this time.
+Odysseyra1n only supports A8(X) to A10(X) on iOS 14.5 at this time.
 {: .notice--warning}
 
 ## Required Reading
 
-If you're on an unsupported firmware version, you can update to {% include latestfw %}.
+If you're on an unsupported firmware version, you can update to {% include latestfw %} and use the Odysseyra1n jailbreak instead if your device is compatible.
 
 This is achieved by simply updating through the Settings application normally. Because the latest version for these devices is {% include latestfw %}, we can easily update to the desired firmware version.
 
@@ -39,3 +39,6 @@ Only follow this if you've installed update blocking in the past.
 1. Tap `General` -> `Software Update`
   - Ensure that the version you are updating to is {% include latestfw %}
 1. Download and install the update
+
+Continue to [Installing Odysseyra1n](installing-odysseyra1n)
+{: .notice--info}


### PR DESCRIPTION
- Add checkra1n 0.12.3/Odysseyn1x 2.10 (aka 14.5 and M1 Mac support)
- Revert commit that added Betelguese (not permanent, just needs an update due to checkra1n no longer using zsh)
- Add M1 Notes for relevant devices
- Alter some stuff with 10.3.3