### PR TITLE
update blob saving guide

### DIFF
--- a/_pages/en_US/saving-blobs/saving-blobs.md
+++ b/_pages/en_US/saving-blobs/saving-blobs.md
@@ -16,7 +16,7 @@ This will take you through the process of saving blobs which are required if you
 
 <button class="btn btn--large btn--info" id="abtn" onclick="showa()">App</button>
 <button class="btn btn--large btn--info" id="bbtn" onclick="showb()">Web</button>
-<button class="btn btn--large btn--info" id="cbtn" onclick="showc()">Computer(A12+)</button>
+<button class="btn btn--large btn--info" id="cbtn" onclick="showc()">Computer (A12+)</button>
 
 {% capture a-instructions %}{% include_relative tss-app.md %}{% endcapture %}
 <div id="ainstr">{{ a-instructions | markdownify }}</div>

--- a/_pages/en_US/saving-blobs/saving-blobs.md
+++ b/_pages/en_US/saving-blobs/saving-blobs.md
@@ -12,11 +12,11 @@ sidebar:
 excerpt: Guide to saving blobs to secure your ability to downgrade iOS in the future.
 ---
 
-This will take you through the process of saving blobs which are required if you wish to downgrade to an older, unsigned version of iOS or iPadOS. You can either use TSS Saver App if you are jailbroken on iOS or use [the TSS Saver website](https://tsssaver.1conan.com/v2/) on A11 and older. If you are using A12+, you will need a computer for this guide.
+This will take you through the process of saving blobs which are required if you wish to downgrade to an older, unsigned version of iOS or iPadOS. You can either use TSS Saver App if you are jailbroken on iOS or use [the TSS Saver website](https://tsssaver.1conan.com/v2/). Unjailbroken A12+ users will need a computer for this guide.
 
 <button class="btn btn--large btn--info" id="abtn" onclick="showa()">App</button>
 <button class="btn btn--large btn--info" id="bbtn" onclick="showb()">Web</button>
-<button class="btn btn--large btn--info" id="cbtn" onclick="showc()">Computer (A12+)</button>
+<button class="btn btn--large btn--info" id="cbtn" onclick="showc()">Computer(A12+)</button>
 
 {% capture a-instructions %}{% include_relative tss-app.md %}{% endcapture %}
 <div id="ainstr">{{ a-instructions | markdownify }}</div>

--- a/_pages/en_US/saving-blobs/tss-app.md
+++ b/_pages/en_US/saving-blobs/tss-app.md
@@ -2,7 +2,8 @@
 
 1. Add the [repo.1conan.com](https://repo.1conan.com/) repo to your sources in your preferred [package manager](package-managers)
 1. Download and install TSS Saver
-1. If you're using unc0ver on iOS14, download and install libkrw; If you're using Taurine on iOS14. download and install libkernrw
+1. If you're using unc0ver on iOS 14, download and install libkrw
+1. If you're using Taurine on iOS 14. download and install libkernrw
 1. Tap "Save Blobs"
 1. Once you receive the confirmation message, tap "Open"
 

--- a/_pages/en_US/saving-blobs/tss-app.md
+++ b/_pages/en_US/saving-blobs/tss-app.md
@@ -2,7 +2,7 @@
 
 1. Add the [repo.1conan.com](https://repo.1conan.com/) repo to your sources in your preferred [package manager](package-managers)
 1. Download and install TSS Saver
-1. If you're using unc0ver on iOS14, download and install libkrw
+1. If you're using unc0ver on iOS14, download and install libkrw; If you're using Taurine on iOS14. download and install libkernrw
 1. Tap "Save Blobs"
 1. Once you receive the confirmation message, tap "Open"
 

--- a/_pages/en_US/saving-blobs/tss-web.md
+++ b/_pages/en_US/saving-blobs/tss-web.md
@@ -1,12 +1,14 @@
 ## Saving Blobs with TSS Saver Website
 A12+ Users will need their ApNonce and Generator pair for this method. If you are not jailbroken, follow [the computer-based guide](https://ios.cfw.guide/saving-blobs#saving-blobs-with-computer-a12).
 {: .notice--info}
+
 ### Getting Generator and ApNonce (Jailbroken A12+ only)
-1. If you are using unc0ver on iOS14, install libkrw; If you are using Taurine on iOS14, install libkernrw
-1. Open a terminal and run `sudo dimentio > dimentio.txt`
+1. If you are using unc0ver on iOS 14, install libkrw
+1. If you are using Taurine on iOS 14, install libkernrw
+1. Open a Terminal app and run `sudo dimentio > dimentio.txt`
     - Alternatively, you can get your Generator and ApNonce from the Generator tab in TSS Saver App
 1. Go to /var/mobile in Filza and open dimentio.txt
-1. copy the 0x number after `Current nonce is` at the bottom of the text file as well as the number that comes after `entangled nonce:`. The 0x number is your Generator, and the entangled nonce number is your ApNonce. Keep these safe somewhere, you'll need them later
+1. Copy the 0x number after `Current nonce is` at the bottom of the text file as well as the number that comes after `entangled nonce:`. The 0x number is your Generator, and the entangled nonce number is your ApNonce. Keep these safe somewhere, you'll need them later
 1. Follow the rest of this guide
 
 ### Saving Blobs (All Devices)

--- a/_pages/en_US/saving-blobs/tss-web.md
+++ b/_pages/en_US/saving-blobs/tss-web.md
@@ -1,5 +1,15 @@
 ## Saving Blobs with TSS Saver Website
+A12+ Users will need their ApNonce and Generator pair for this method. If you are not jailbroken, follow [the computer-based guide](https://ios.cfw.guide/saving-blobs#saving-blobs-with-computer-a12).
+{: .notice--info}
+### Getting Generator and ApNonce (Jailbroken A12+ only)
+1. If you are using unc0ver on iOS14, install libkrw; If you are using Taurine on iOS14, install libkernrw
+1. Open a terminal and run `sudo dimentio > dimentio.txt`
+    - Alternatively, you can get your Generator and ApNonce from the Generator tab in TSS Saver App
+1. Go to /var/mobile in Filza and open dimentio.txt
+1. copy the 0x number after `Current nonce is` at the bottom of the text file as well as the number that comes after `entangled nonce:`. The 0x number is your Generator, and the entangled nonce number is your ApNonce. Keep these safe somewhere, you'll need them later
+1. Follow the rest of this guide
 
+### Saving Blobs (All Devices)
 1. Connect your iOS Device to your Mac or PC
 1. Open iTunes or Finder
   - Windows users must download the [normal version](https://www.apple.com/itunes/) NOT the Windows Store version
@@ -11,6 +21,7 @@
 1. Input your device ECID
 1. Select your Device
     - iPhone 6S, 6S Plus, and iPhone SE users will need to get their board configuration by [downloading this app](https://itunes.apple.com/us/app/ax-cpu/id1048174418?mt=8)
+    - A12+ users will need to input ApNonce and Generator pair
 1. Click Submit
 
 {% include_relative include/end-of-page.md %}


### PR DESCRIPTION
I updated the blob saving guide, since the guide previously implied that you can't save blobs without a computer on A12+. I changed the blurb to be more clear about this, and added a section about getting your generator and apnonce to the saving via web section. I'm not sure how useful it really is because you still need your apnonce and generator and if you're doing that you might as well use the app but hey. I also added a note about libkernrw for Taurine users in the app section. 

Hopefully I didn't mess up the markdown or anything!