### PR TITLE
Add troubleshooting info from Sileo discord

### DIFF
--- a/_pages/en_US/jailbreak/installing-odyssey.md
+++ b/_pages/en_US/jailbreak/installing-odyssey.md
@@ -57,7 +57,7 @@ The Odyssey application can now be opened from home screen.
 If the app or your device crashes/restarts unexpectedly and the jailbreak isn't installed, simply try rebooting and running the exploit again until it does work.
 {:.notice--danger}
 
-If you receive the error `ERR_Jailbreak`, read the [Troubleshooting](troubleshooting#err_jailbreak) page
+If you receive the error `ERR_Jailbreak`, `ERR_Already_Jailbroken` or `ERR_TFP0` read the Taurine/Odyssey section on the [Troubleshooting](troubleshooting#taurine_odyssey) page
 {: .notice--info}
 
 You should now be jailbroken with Sileo installed on your home screen. You can use Sileo to install [tweaks](faq#tweaks), themes and more.

--- a/_pages/en_US/jailbreak/installing-taurine.md
+++ b/_pages/en_US/jailbreak/installing-taurine.md
@@ -57,7 +57,7 @@ If you restored rootFS, go back to step 1 and repeat this section.
 If the app or your device crashes/restarts unexpectedly and the jailbreak isn't installed, simply try rebooting and running the exploit again until it does work.
 {:.notice--danger}
 
-If you receive the error `ERR_Jailbreak`, read the [Troubleshooting](troubleshooting#err_jailbreak) page
+If you receive the error `ERR_Jailbreak`, `ERR_Already_Jailbroken` or `ERR_KernRW` read the Taurine/Odyssey section on the [Troubleshooting](troubleshooting#taurine_odyssey) page
 {: .notice--info}
 
 You should now be jailbroken with Sileo installed on your home screen. You can use Sileo to install [tweaks](faq#tweaks), themes and more.

--- a/_pages/en_US/troubleshooting.md
+++ b/_pages/en_US/troubleshooting.md
@@ -19,17 +19,27 @@ sidebar:
 
 Your device should now be in DFU mode. The screen should be black, and your computer should recognise it as in recovery mode.
 
-## <a name="err_jailbreak" />ERR_Jailbreak on Odyssey and Taurine
+## <a name="taurine_odyssey" />Common Errors on Odyssey and Taurine
 
+### ERR_Jailbreak
 This is caused by you having used a previous jailbreak. To solve this, you need to restore rootfs:
 
 1. Reboot the device.
-1. Open the Odyssey or Taurine, depending on your iOS version.
+1. Open the Odyssey or Taurine app, depending on your iOS version.
 1. Toggle the `Restore Rootfs` option
 1. Press the Jailbreak button.
 
 Once the restore rootfs successfully completes, try jailbreaking again.
 
+### ERR_Already_Jailbroken and ERR_KernRW (Taurine)/ERR_TFP0 (Odyssey)
+`ERR_Already_Jailbroken` indicates that the jailbreak process was interrupted. `ERR_KernRW` and `ERR_TFP0` indicate that the exploit failed. Both can be solved in the same way:
+
+1. Reboot the device.
+1. Open the Odyssey or Taurine app, depending on your iOS version.
+1. Press the Jailbreak button.
+
+Jailbreaks are hardly ever 100% successful, you may need to re-attempt running the jailbreak multiple times
+{: .notice--info}
 ## <a name="rootfs_u0" />rootFS already mounted
 
 1. Open the Settings application


### PR DESCRIPTION
I added some extra errors that can appear in Taurine/Odyssey and how to solve them based on info from the Sileo discord. I also updated the err_jailbreak link to a more general name (taurine_odyssey). 