### PR TITLE
Minor changes to some wording and versions recommended.

### DIFF
--- a/_pages/en_US/jailbreak/checkra1n/using-odysseyn1x.md
+++ b/_pages/en_US/jailbreak/checkra1n/using-odysseyn1x.md
@@ -23,10 +23,7 @@ sidebar:
 
 Odysseyn1x is a live bootable Linux environment that allows you to quickly run checkra1n on a compatible device. checkra1n is capable of jailbreaking millions of iOS device on firmwares 12.0 and above.
 
-On iOS 14.0 to 14.4.2 Odysseyra1n is only fully supported on A8(X) to A10(X) devices with limited support (no security) for A11 devices. For more information, see [Regarding Odysseyra1n on A11](information-regarding-a11).
-{: .notice--danger}
-
-On iOS 14.5 to {% include latestfw %} Odysseyra1n is only fully supported on A8(X), A9, and A10(X) devices with limited support (no security) for A11 devices. For more information, see [Regarding Odysseyra1n on A11](information-regarding-a11).
+On iOS 14.0 to {% include latestfw %}, Odysseyra1n is only fully supported on A8(X), A9, and A10(X) devices. A9X devices are only fully supported on 14.0 to 14.4.2. All A11 devices have limited support with no security. For more information, see [Regarding Odysseyra1n on A11](information-regarding-a11).
 {: .notice--danger}
 
 {% include_relative include/odysseyra1n-explanation.md %}

--- a/_pages/en_US/jailbreak/installing-taurine.md
+++ b/_pages/en_US/jailbreak/installing-taurine.md
@@ -23,7 +23,7 @@ Taurine is currently signed at [jailbreaks.app](https://jailbreaks.app/) for eas
 
 <script src="/assets/js/if_jailbreaksapp_signed.js"></script>
 
-- The latest version of [Taurine](https://taurine.app/)
+- The 1.0.4 version of [Taurine](https://github.com/Odyssey-Team/Taurine/releases/tag/1.0.4)
 - The latest version of [AltStore](http://altstore.io/)
 - The latest version of [iTunes](https://www.apple.com/itunes/download/win32) if on Windows
 - The latest version of [iCloud](https://secure-appldnld.apple.com/windows/061-91601-20200323-974a39d0-41fc-4761-b571-318b7d9205ed/iCloudSetup.exe) if on Windows

--- a/_pages/en_US/jailbreak/installing-unc0ver.md
+++ b/_pages/en_US/jailbreak/installing-unc0ver.md
@@ -34,7 +34,7 @@ unc0ver is currently signed at [jailbreaks.app](https://jailbreaks.app/) for eas
 
 <script src="/assets/js/if_jailbreaksapp_signed.js"></script>
 
-- The latest version of [unc0ver](https://unc0ver.dev/)
+- The 6.1.1 version of [unc0ver](https://unc0ver.dev/downloads/6.1.1/decf7c36cc08118dc83ba455f8ca42e0e3cf354c/unc0ver_Release_6.1.1.ipa/)
 - The latest version of [AltStore](http://altstore.io/)
 - The latest version of [iTunes](https://www.apple.com/itunes/download/win32) if on Windows
 - The latest version of [iCloud](https://secure-appldnld.apple.com/windows/061-91601-20200323-974a39d0-41fc-4761-b571-318b7d9205ed/iCloudSetup.exe) if on Windows


### PR DESCRIPTION
Following is changed:
- Odysseyn1x notice updated to be aligned with Odysseyra1n
- unc0ver version linked switched to 6.1.1 (6.1.2 is buggy garbage)
- Taurine version linked switched to 1.0.4 (1.0.5 has some issues with BSoD and somewhat rare bootloop issues)