### PR TITLE
Update h3lix guide to reflect changes w.r.t AltDeploy & Big Sur

### DIFF
--- a/_pages/en_US/jailbreak/installing-h3lix.md
+++ b/_pages/en_US/jailbreak/installing-h3lix.md
@@ -18,7 +18,7 @@ Note that the h3lix jailbreak is not “persistent” (meaning it does not remai
 
 Due to how custom applications are installed to the device, in most cases you will need to reinstall the h3lix jailbreak application to your device every 7 days from your computer.
 
-We will use iOS-App-Signer, Xcode, and a patcher script to achieve this.
+We will use iOS-App-Signer, Xcode, and a patcher script to install the application to your device.
 
 ## Downloads
 

--- a/_pages/en_US/jailbreak/installing-h3lix.md
+++ b/_pages/en_US/jailbreak/installing-h3lix.md
@@ -18,27 +18,45 @@ Note that the h3lix jailbreak is not “persistent” (meaning it does not remai
 
 Due to how custom applications are installed to the device, in most cases you will need to reinstall the h3lix jailbreak application to your device every 7 days from your computer.
 
-We will use the AltDeploy tool to install the h3lix jailbreak application to your iOS device for use in the next step.
+We will use iOS-App-Signer, Xcode, and a patcher script to achieve this.
 
 ## Downloads
 
 - The latest version of [h3lix](https://h3lix.tihmstar.net/)
-- The latest version of [AltDeploy](https://github.com/pixelomer/AltDeploy/releases)
+- The latest version of [iOS-App-Signer](https://github.com/DanTheMan827/ios-app-signer/releases)
+- Jackajames' [patcher script](https://gist.github.com/jakeajames/b44d8db345769a7149e97f5e155b3d46)
+- A Mac with Xcode installed
 
-![]({{ "/assets/images/altdeploy.png" | absolute_url }})
+
 {: .notice--info}
 
-## Installing the application
+## Patching the application
 
-1. Open AltDeploy
-1. Plug your iOS device into your computer
-  - Make sure your computer is trusted and allowed to view the contents of your device
-1. Drag and drop the h3lix `.ipa` file into AltDeploy
-1. Enter in your Apple ID
-1. Enter in your pasword
-  - This information is sent to Apple only
+1. Open Terminal
+2. Change directory to the folder where you saved the script and h3lix.ipa files
+   - If you saved them to Downloads, this would be `cd ~/Downloads`
+3. Type `./patch.sh` in the terminal then drag in the h3lix ipa, type `h3lix.ipa` then press enter
 
-The app will now install to your iOS device.
+You now have a patched h3lix ipa that you can sign
+
+## Signing the application
+
+1. Open Xcode and create a new application project called Test
+2. Click on the top instance of Test in the files sidebar
+3. Click on Test under Targets
+4. Click on Signing and Capabilities and follow the steps to create a signing certificate and enter your Apple ID when prompted
+5. Open iOS-App-Signer
+6. Click browse and choose the patched h3lix ipa we made earlier
+7. Your Apple ID will be in the Signing Certificate box, but if it isn't, select it from the dropdown list
+8. Change the Provisioning Profile option to the provisioning profile corresponding to your Xcode project name (this should be Test)
+9. Click start, then save, saying yes to overwriting any other files of the same name
+
+## Sideloading the application
+
+1. Plug your device into your Mac and press trust if it prompts you
+2. In Xcode, click on Window in the global menu and select Devices and Simulators
+3. Select your device in the window
+4. Press the plus button under Installed Applications and select the h3lix ipa we made in the previous section
 
 ## Trusting the application
 
@@ -53,6 +71,9 @@ The h3lix application can now be opened from home screen.
 
 1. Open the h3lix application from your home screen
 1. Tap "Jailbreak"
+
+If the app displays `Uicache Failed!` this means the signing process was not done properly and you should double check you followed the steps above properly
+{: .notice--info}
 
 If your device crashes or restarts unexpectedly and the jailbreak isn't installed, simply try running the exploit again until it does work.
 {:.notice--danger}

--- a/_pages/en_US/jailbreak/installing-h3lix.md
+++ b/_pages/en_US/jailbreak/installing-h3lix.md
@@ -32,24 +32,27 @@ We will use iOS-App-Signer, Xcode, and a patcher script to install the applicati
 
 ## Patching the application
 
-1. Open Terminal
-2. Change directory to the folder where you saved the script and h3lix.ipa files
+1. Open the Terminal application
+1. Change directory to the folder where you saved the script and h3lix.ipa files
    - If you saved them to Downloads, this would be `cd ~/Downloads`
-3. Type `./patch.sh` in the terminal then drag in the h3lix ipa, type `h3lix.ipa` then press enter
+1. Type `./patch.sh` in the terminal
+1. Drag and drop the h3lix `.ipa` file into the terminal
+1. Type "h3lix.ipa"
+1. Press Enter
 
 You now have a patched h3lix ipa that you can sign
 
 ## Signing the application
 
 1. Open Xcode and create a new application project called Test
-2. Click on the top instance of Test in the files sidebar
-3. Click on Test under Targets
-4. Click on Signing and Capabilities and follow the steps to create a signing certificate and enter your Apple ID when prompted
-5. Open iOS-App-Signer
-6. Click browse and choose the patched h3lix ipa we made earlier
-7. Your Apple ID will be in the Signing Certificate box, but if it isn't, select it from the dropdown list
-8. Change the Provisioning Profile option to the provisioning profile corresponding to your Xcode project name (this should be Test)
-9. Click start, then save, saying yes to overwriting any other files of the same name
+1. Click on the top instance of Test in the files sidebar
+1. Click on Test under Targets
+1. Click on Signing and Capabilities and follow the steps to create a signing certificate and enter your Apple ID when prompted
+1. Open iOS-App-Signer
+1. Click browse and choose the patched h3lix ipa we made earlier
+1. Your Apple ID will be in the Signing Certificate box, but if it isn't, select it from the dropdown list
+1. Change the Provisioning Profile option to the provisioning profile corresponding to your Xcode project name (this should be Test)
+1. Click start, then save, saying yes to overwriting any other files of the same name
 
 ## Sideloading the application
 


### PR DESCRIPTION
i've basically rewritten the h3lix guide to reflect the steps required on Big Sur and later. I included a link to a patcher script someone made that essentially lets you sign the ipa yourself without tripping tihmstar's DRM but i'm not sure if that's legal or whatever. 
Also this whole guide is kinda convoluted, thanks to yknow, the DRM and the fact that certain things no longer work on Big Sur and later (unless we tell people to disable SIP and Gatekeeper LOL)