### PR TITLE
Ryzen issues with checkra1n

### DIFF
--- a/_pages/en_US/jailbreak/checkra1n/ra1n-linux.md
+++ b/_pages/en_US/jailbreak/checkra1n/ra1n-linux.md
@@ -1,3 +1,6 @@
+If you are using a computer with an AMD Ryzen CPU, this will likely not work for you, you should use a Mac or a computer with an Intel CPU to follow this guide if this is the case.
+{: .notice--warning}
+
 ## Downloads (Linux)
 
 - The latest release of [checkra1n](https://checkra.in)

--- a/_pages/en_US/jailbreak/checkra1n/ra1n-linux.md
+++ b/_pages/en_US/jailbreak/checkra1n/ra1n-linux.md
@@ -1,4 +1,4 @@
-If you are using a computer with an AMD Ryzen CPU, this will likely not work for you, you should use a Mac or a computer with an Intel CPU to follow this guide if this is the case.
+If you are using a computer with an AMD Ryzen CPU, you will likely run into issues. If you do run into issues, you should use a Mac or a computer with an Intel CPU to follow this guide.
 {: .notice--warning}
 
 ## Downloads (Linux)

--- a/_pages/en_US/jailbreak/checkra1n/using-odysseyn1x.md
+++ b/_pages/en_US/jailbreak/checkra1n/using-odysseyn1x.md
@@ -26,7 +26,7 @@ Odysseyn1x is a live bootable Linux environment that allows you to quickly run c
 On iOS 14.0 to {% include latestfw %}, Odysseyra1n is only fully supported on A8(X), A9, and A10(X) devices. A9X devices are only fully supported on 14.0 to 14.4.2. All A11 devices have limited support with no security. For more information, see [Regarding Odysseyra1n on A11](information-regarding-a11).
 {: .notice--danger}
 
-If you are using a computer with an AMD Ryzen CPU, this will likely not work for you, you should use a Mac or a computer with an Intel CPU to follow this guide if this is the case.
+If you are using a computer with an AMD Ryzen CPU, you will likely run into issues. If you do run into issues, you should use a Mac or a computer with an Intel CPU to follow this guide.
 {: .notice--warning}
 
 {% include_relative include/odysseyra1n-explanation.md %}

--- a/_pages/en_US/jailbreak/checkra1n/using-odysseyn1x.md
+++ b/_pages/en_US/jailbreak/checkra1n/using-odysseyn1x.md
@@ -26,6 +26,9 @@ Odysseyn1x is a live bootable Linux environment that allows you to quickly run c
 On iOS 14.0 to {% include latestfw %}, Odysseyra1n is only fully supported on A8(X), A9, and A10(X) devices. A9X devices are only fully supported on 14.0 to 14.4.2. All A11 devices have limited support with no security. For more information, see [Regarding Odysseyra1n on A11](information-regarding-a11).
 {: .notice--danger}
 
+If you are using a computer with an AMD Ryzen CPU, this will likely not work for you, you should use a Mac or a computer with an Intel CPU to follow this guide if this is the case.
+{: .notice--warning}
+
 {% include_relative include/odysseyra1n-explanation.md %}
 
 ## Requirements


### PR DESCRIPTION
checkra1n on AMD Ryzen CPU's **in most cases** will not work for users, regardless of whether or not they are using checkra1n in an actually installed thing of Linux (e.g. Ubuntu) or Odysseyn1x.

This PR adds a notice to the start of the Linux section and on the Odysseyn1x page that users using AMD Ryzen CPU's will **likely** run into issues, and that they should attempt to obtain a mac or a computer with an Intel CPU to follow the guide.