### PR TITLE
Remove reboot from Taurine and Odysseyra1n guides

### DIFF
--- a/_pages/en_US/jailbreak/checkra1n/include/end-of-page.md
+++ b/_pages/en_US/jailbreak/checkra1n/include/end-of-page.md
@@ -13,7 +13,7 @@ Before you can start installing anything else, you first need to install a few n
 1. Tap the "Get" button
 1. Tap on the "Queued" bar at the bottom of your screen
 1. Tap "Confirm"
-1. Reboot your device and re-jailbreak with checkra1n
+1. Once finished, tap 'Restart SpringBoard'
 
 Continue to [Using Sileo](using-sileo)
 {: .notice--info}

--- a/_pages/en_US/jailbreak/installing-taurine.md
+++ b/_pages/en_US/jailbreak/installing-taurine.md
@@ -72,7 +72,7 @@ You should now be jailbroken with Sileo installed on your home screen. You can u
 1. Search for "PreferenceLoader" and "RocketBootstrap" and add them to the queue by pressing "Install"
 1. Tap the "Queued" bar at the bottom of the page
 1. Tap "Confirm"
-1. Once finished, restart your device and re-jailbreak using Taurine
+1. Once finished, tap 'Restart SpringBoard'
 
 Continue to [Using Sileo](using-sileo)
 {: .notice--info}


### PR DESCRIPTION
The guides tell people to reboot their devices. This is not necessary unless people use tweaks that require injection into daemons other than SpringBoard. In that case they'd need to reboot or do a userspace reboot later anyways. For Odysseyra1n rebooting was actually the easiest way to activate libhooker in the past but with recent libhooker versions that's not needed anymore. 