### PR TITLE
fix wrong button text

### DIFF
--- a/docs/en_US/include/using-cydia
+++ b/docs/en_US/include/using-cydia
@@ -42,7 +42,7 @@ The repo should now be removed from Cydia.
 1. Tap the `Install` button at the top right-hand corner of your screen
 1. Confirm the installation
     - It may take some time for the tweak to install
-1. After it's finished, tap "[Restart Springboard]((/faq/#what-is-respringing))"
+1. After it's finished, tap "[Restart SpringBoard]((/faq/#what-is-respringing))"
     - The device should appear to reboot after this
     - Sometimes, the button might not say to respring, but you can tap the button anyway
 

--- a/docs/en_US/include/using-cydia
+++ b/docs/en_US/include/using-cydia
@@ -42,7 +42,7 @@ The repo should now be removed from Cydia.
 1. Tap the `Install` button at the top right-hand corner of your screen
 1. Confirm the installation
     - It may take some time for the tweak to install
-1. After it's finished, tap "[Respring]((/faq/#what-is-respringing))"
+1. After it's finished, tap "[Restart Springboard]((/faq/#what-is-respringing))"
     - The device should appear to reboot after this
     - Sometimes, the button might not say to respring, but you can tap the button anyway
 

--- a/docs/en_US/include/using-cydia
+++ b/docs/en_US/include/using-cydia
@@ -44,7 +44,7 @@ The repo should now be removed from Cydia.
     - It may take some time for the tweak to install
 1. After it's finished, tap "[Restart SpringBoard]((/faq/#what-is-respringing))"
     - The device should appear to reboot after this
-    - Sometimes, the button might not say to respring, but you can tap the button anyway
+    - Sometimes, the button might not say to Restart SpringBoard, but you can tap the button anyway
 
 The tweak should now be installed to your device and will be active whenever your device is jailbroken.
 
@@ -56,8 +56,8 @@ The tweak should now be installed to your device and will be active whenever you
 1. Tap `Remove`
 1. Confirm the uninstallation
     - It may take some time for the tweak to install
-1. After it's finished, tap "[Respring]((/faq/#what-is-respringing))"
+1. After it's finished, tap "[Restart SpringBoard]((/faq/#what-is-respringing))"
     - The device should appear to reboot after this
-    - Sometimes, the button might not say to respring, but you can tap the button anyway
+    - Sometimes, the button might not say to Restart SpringBoard, but you can tap the button anyway
 
-After respringing, the tweak should now be uninstalled.
+After restarting SpringBoard, the tweak should now be uninstalled.


### PR DESCRIPTION
In Cydia, the button says "Restart SpringBoard", not "Respring". This PR fixes this.