### PR TITLE
Remove instructions on adding chariz on futurerestore pages 

### DIFF
--- a/docs/en_US/updating/futurerestore-help.md
+++ b/docs/en_US/updating/futurerestore-help.md
@@ -37,7 +37,7 @@ To fix this:
 
 ## Device ApNonce doesn't match APTicket nonce
 
-This error means that you have not set your generator on your device to that of the blob. In order to solve this problem, follow the `Setting nonce` part of the <router-link to="/futurerestore-help">FutureRestore page</router-link>
+This error means that you have not set your generator on your device to that of the blob. In order to solve this problem, follow the `Setting nonce` part of the <router-link to="/futurerestore">FutureRestore page</router-link>
 
 ## SEP Firmware is not being signed
 

--- a/docs/en_US/updating/futurerestore-help.md
+++ b/docs/en_US/updating/futurerestore-help.md
@@ -10,6 +10,7 @@ redirect_from:
 extra_contributors:
   - Tanbeer191
   - TheHacker894
+  - Serena
 ---
 
 ## Help page
@@ -36,33 +37,7 @@ To fix this:
 
 ## Device ApNonce doesn't match APTicket nonce
 
-This error means that you have not set your generator on your device to that of the blob. In order to solve this problem:
-
-### Getting Started
-
-1. Open your package manager on your jailbroken iDevice
-1. Add [repo.1conan.com](https://repo.1conan.com) to your sources
-1. Add [repo.chariz.com](https://repo.chariz.com) to your sources
-    - This will usually already be there on newer jailbreaks
-1. Download and install dimentio
-1. Download and install NewTerm2
-
-### Setting nonce
-
-1. Open your blob in a text editor and search for `generator`
-![GeneratorExample](https://user-images.githubusercontent.com/48022799/117004373-aa0b6700-acee-11eb-8a70-c488163e349b.jpeg) 
-   - This should be a `0x` followed by 16 characters, which will be a combination of letters and numbers.
-1. Note that value down. This is your generator.
-
-**NOTE:** If there is no generator value, try to remember which jailbreak you were using at the time of saving blobs. If you were using unc0ver, your generator is most likely `0x1111111111111111`, and if you were using Chimera/Odyssey/Taurine, your generator is most likely `0xbd34a880be0b53f3`.
-
-3. Open NewTerm 2 on your iDevice and type the following command, where `[generator]` is the value you just grabbed: `su root -c 'dimentio [generator]'`
-    
-1. When asked for a password, enter your root password
-    - By default, this is set to `alpine`
-1. Once the command executes, a lot of text should appear
-1. Near the end of the text, you should see the line `Set nonce to [generator]`
-1. Run FutureRestore again. This issue should now be resolved.
+This error means that you have not set your generator on your device to that of the blob. In order to solve this problem, follow the `Setting nonce` part of the <router-link to="/futurerestore-help">FutureRestore page</router-link>
 
 ## SEP Firmware is not being signed
 

--- a/docs/en_US/updating/futurerestore-help.md
+++ b/docs/en_US/updating/futurerestore-help.md
@@ -10,7 +10,6 @@ redirect_from:
 extra_contributors:
   - Tanbeer191
   - TheHacker894
-  - Serena
 ---
 
 ## Help page

--- a/docs/en_US/updating/futurerestore-help.md
+++ b/docs/en_US/updating/futurerestore-help.md
@@ -46,10 +46,6 @@ This error means that you have not set your generator on your device to that of 
     - This will usually already be there on newer jailbreaks
 1. Download and install dimentio
 1. Download and install NewTerm2
-1. If you're on iOS 14.0 or above:
-    - Install `libkernrw` if you're using Taurine
-    - Install `libkrw` if you're using unc0ver
-    - checkra1n/odysseyra1n users don't need to install anything extra
 
 ### Setting nonce
 

--- a/docs/en_US/updating/futurerestore.md
+++ b/docs/en_US/updating/futurerestore.md
@@ -18,8 +18,7 @@ If you are on iOS 15, you will need to follow [this](https://gist.github.com/nyu
 ## Requirements
 
 - Blobs saved for the version you want to restore to
-- A jailbroken iDevice
-- A computer with at least 8 gigabytes of available space (not including the ipsw)
+- a jailbroken device
 
 ## Downloads
 
@@ -33,8 +32,6 @@ If you are on iOS 15, you will need to follow [this](https://gist.github.com/nyu
 
 1. Open your package manager on your jailbroken iDevice
 1. Add [repo.1conan.com](https://repo.1conan.com) to your sources
-1. Add [repo.chariz.com](https://repo.chariz.com) to your sources
-    - This will usually already be there on newer jailbreaks
 1. Download and install dimentio
 1. Download and install NewTerm2
 
@@ -62,14 +59,14 @@ If you are on iOS 15, you will need to follow [this](https://gist.github.com/nyu
 1. Open FutureRestoreGUI on your computer
     - If prompted by Windows Defender or other anti-virus software, allow the program to run - it’s safe
 1. When opening FutureRestoreGUI, you should be greeted by this menu:
-![image](https://user-images.githubusercontent.com/48022799/126875170-142c9d15-8bd3-420e-bd59-18a6df8fc6eb.png)
+![image](https://user-images.githubusercontent.com/48022799/147845013-73dbda5b-500d-4f5a-ae51-3751d9268fe6.png)
 
 1. Click the `Download FutureRestore` button to fetch the latest version of FutureRestore
 ** Note:** For A14 and WiFi only-iPad users, you will need to click the `Settings` button and press `Futurerestore beta`, then click the `Download FutureRestore` button.
 1. Click the `Select Blob File...` button and select your blob .shsh2 file
 1. Click the `Select Target iPSW File...` and select your .ipsw file
 1. Then click the Next button to navigate to the Options menu, make sure `Extra Logs` is enabled
-1. If you are upgrading or restoring to the same version the device is on, you may enable `Preserve Data` to keep data, however do not use this when downgrading. Especially when downgrading from 14.5 to a lower version, as that will result in a recovery loop.
+1. If you are not downgrading, then it is safe to enable `Preserve Data` in the options menu in order to keep data. However using it while downgrading may be dangerous
 1. Do not enable `AP Nonce Collision` on any modern devices
 1. Click Next to navigate to the controls menu
 1. Click `Start Futurerestore`

--- a/docs/en_US/updating/futurerestore.md
+++ b/docs/en_US/updating/futurerestore.md
@@ -18,7 +18,7 @@ If you are on iOS 15, you will need to follow [this](https://gist.github.com/nyu
 ## Requirements
 
 - Blobs saved for the version you want to restore to
-- a jailbroken device
+- A jailbroken device
 
 ## Downloads
 


### PR DESCRIPTION
and remove copy-pasted instructions on how to set nonce in futurerestore-help, instead, redirect the users to the original fr page to see how to set nonce