### PR TITLE
Fix bundle ID for Takarek MobilApp

### DIFF
--- a/docs/.vuepress/json/bypassApps/ios.cardinal.takarekinfo.json
+++ b/docs/.vuepress/json/bypassApps/ios.cardinal.takarekinfo.json
@@ -1,6 +1,6 @@
 {
   "name": "Takarék MobilApp",
-  "bundleId": "ios.cardinal.takinfo",
+  "bundleId": "ios.cardinal.takarekinfo",
   "uri": "https://apps.apple.com/hu/app/takar%C3%A9k-mobilapp/id1464905099",
   "icon": "https://is4-ssl.mzstatic.com/image/thumb/Purple116/v4/3e/fd/be/3efdbed6-db54-fef0-5719-241ddbdf5a5c/source/512x512bb.jpg",
   "bypasses": [


### PR DESCRIPTION
The bundle ID for Takarek MobilApp as returned by the iTunes lookup API is `ios.cardinal.takarekinfo`:


```
❯ curl --silent 'https://itunes.apple.com/hu/lookup?id=1464905099' | jq '.results[0].bundleId'
"ios.cardinal.takarekinfo"
```