### PR TITLE
checkra1n: Add instructions for Debian-based distros

### DIFF
--- a/docs/en_US/jailbreak/checkra1n/installing-odysseyra1n/ra1n-linux.md
+++ b/docs/en_US/jailbreak/checkra1n/installing-odysseyra1n/ra1n-linux.md
@@ -32,6 +32,12 @@ If you do have issues, get a USB-A to Lightning cable and, if necessary, also ge
 
 ## Installing checkra1n
 
+checkra1n provides native support to machines running a Debian-based distro (e.g Ubuntu). It's
+recommended that you follow [specific instructions](https://checkra.in/linux) provided by the
+checkra1n team themselves.
+
+However, if that doesn't work, attempt the following
+
 1. Run the `checkra1n` binary in the terminal using `./checkra1n`
     - You may need to run `sudo chmod a+x ./checkra1n` if the binary doesn't run
     - If you're on an A11 device, you will need to head into `Options`, then enable the `Skip A11 BPR Check` option once it runs

--- a/docs/en_US/jailbreak/checkra1n/installing-odysseyra1n/ra1n-linux.md
+++ b/docs/en_US/jailbreak/checkra1n/installing-odysseyra1n/ra1n-linux.md
@@ -32,11 +32,13 @@ If you do have issues, get a USB-A to Lightning cable and, if necessary, also ge
 
 ## Installing checkra1n
 
+::: tip
+
 checkra1n provides native support to machines running a Debian-based distro (e.g Ubuntu). It's
 recommended that you follow [specific instructions](https://checkra.in/linux) provided by the
 checkra1n team themselves.
 
-However, if that doesn't work, attempt the following
+:::
 
 1. Run the `checkra1n` binary in the terminal using `./checkra1n`
     - You may need to run `sudo chmod a+x ./checkra1n` if the binary doesn't run


### PR DESCRIPTION
This PR adds specific instructions, provided by the checkra1n team, for Debian-based distros to the Linux section of the checkra1n guide. Considering that this is the method that is recommended by the checkra1n team, there's no reason to not mention this in the guide, considering how much easier it is.