### PR TITLE
update futurerestore guide

### DIFF
--- a/docs/en_US/updating/futurerestore.md
+++ b/docs/en_US/updating/futurerestore.md
@@ -73,10 +73,11 @@ You **must** make sure that the latest SEP/BB is compatible to the version you a
 1. Open FutureRestoreGUI on your computer
     - If prompted by Windows Defender, Windows Smartscreen or other anti-virus software, allow the program to run - it’s safe
 1. When opening FutureRestoreGUI, you should be greeted by this menu:
-![image](https://user-images.githubusercontent.com/48022799/147845013-73dbda5b-500d-4f5a-ae51-3751d9268fe6.png)
+![image](https://user-images.githubusercontent.com/48022799/147845013-73dbda5b-500d-4f5a-ae51-3751d9268fe6.png](https://media.discordapp.net/attachments/594022956313608204/1025256111479197756/unknown.png)
 
 1. Click the `Download FutureRestore` button to fetch the latest version of FutureRestore
-** Note:** If your device supports iOS 15 or is a WiFi only-iPad, you will need to click the `Settings` button and enable `Futurerestore Beta`, then click the `Download FutureRestore` button. 
+** Note:** If your device supports iOS 15 or is a WiFi only-iPad, you will need to click the `Settings` button and enable `Futurerestore Beta`, then click the `Download FutureRestore` button. **This option is only available for macOS and Linux**
+  - Windows users must download the beta from [here](https://cdn.discordapp.com/attachments/917198974555942942/1023188228972494858/futurerestore_292_local_win_x64.exe). Once that is done, press `Select FutureRestore Binary/Executable` and navigate to where you have downloaded the beta. Select the file and click `Open`
 1. Click the `Select Blob File...` button and select your blob .shsh2 file
 1. Click the `Select Target iPSW File...` and select your .ipsw file
 1. Then click the Next button to navigate to the Options menu, make sure `Extra Logs` is enabled

--- a/docs/en_US/updating/futurerestore.md
+++ b/docs/en_US/updating/futurerestore.md
@@ -17,6 +17,7 @@ If you are on iOS 15.2 or newer on an A11- device, you should follow [this](http
 ## Requirements
 
 - Blobs saved for the version you want to restore to
+  - These blobs must be for **your** device only; you cannot use other people's blobs
 - A jailbroken device **or** an A10+ device on 15.0-15.1.1
 
 ::: danger
@@ -52,6 +53,12 @@ You **must** make sure that the latest SEP/BB is compatible to the version you a
 3. Proceed to the next section
 
 ## Finding the generator
+
+::: danger
+
+Make sure you do not edit the blob file! Doing so will make it invalid and unusable with futurerestore.
+
+:::
 
 1. Open your blob in a text editor and search for `generator`
    ![GeneratorExample](https://user-images.githubusercontent.com/48022799/117004373-aa0b6700-acee-11eb-8a70-c488163e349b.jpeg) 

--- a/docs/en_US/updating/futurerestore.md
+++ b/docs/en_US/updating/futurerestore.md
@@ -12,12 +12,12 @@ extra_contributors:
   - CoocooFroggy
 ---
 ## Notes
-If you are on iOS 15, you will need to follow [this](https://gist.github.com/nyuszika7h/aac55c97f7925cddcf5ec3167f85dfe8) guide instead. Note that if you are on iOS 15 and are on an A12+ device, you will not be able to downgrade, as there is currently no jailbreak or exploits which can be used to set nonce on A12+ devices running iOS 15.
+If you are on iOS 15.2 or newer on an A11- device, you should follow [this](https://gist.github.com/nyuszika7h/aac55c97f7925cddcf5ec3167f85dfe8) guide instead. Note that if you are on iOS 15.2 or newer and are on an A12+ device, you will not be able to downgrade, as there is currently no jailbreak or exploits which can be used to set nonce on A12+ devices running iOS 15.2 or newer.
 
 ## Requirements
 
 - Blobs saved for the version you want to restore to
-- A jailbroken device
+- A jailbroken device **or** a device on 15.0-15.1.1
 
 ## Downloads
 
@@ -26,6 +26,9 @@ If you are on iOS 15, you will need to follow [this](https://gist.github.com/nyu
   - This should be the same iOS version as your blob
 - On Windows, make sure you have [iTunes](https://www.apple.com/itunes/) installed
   - Scroll down and select the other Windows build as the Windows Store version will not work
+- If on an iOS 15.0-15.1.1 device
+  - The latest version of [TrollStore](https://github.com/opa334/TrollStore/releases)
+  - The latest version of [TrollNonce](https://github.com/opa334/TrollNonce/releases)
 
 ## Getting Started
 
@@ -56,24 +59,32 @@ If you're using unc0ver on iOS 14.6-14.8, you cannot use dimentio as libkrw isn'
     - By default, this is set to `alpine`, not your phone's password.
 1. Once the command executes, a lot of text should appear
 1. Near the end of the text, you should see the line `Set nonce to [generator]`
+
+::: danger
+
+You **must** make sure that the latest SEP/BB is compatible to the version you are attempting to restore to in order to prevent bootloops! To do so, please consult the [SEP/BB Chart](https://docs.google.com/spreadsheets/d/1Mb1UNm6g3yvdQD67M413GYSaJ4uoNhLgpkc7YKi3LBs/edit#gid=0). If a cell says "Compatible" then you are free to restore to that version.
+
+:::
  
 ### On Computer 
 1. Connect your iDevice to your computer
 1. Make sure that your computer is trusted by your device
     - Optionally, you can create a full backup of your device through iTunes or Finder
 1. Open FutureRestoreGUI on your computer
-    - If prompted by Windows Defender or other anti-virus software, allow the program to run - it’s safe
+    - If prompted by Windows Defender, Windows Smartscreen or other anti-virus software, allow the program to run - it’s safe
 1. When opening FutureRestoreGUI, you should be greeted by this menu:
 ![image](https://user-images.githubusercontent.com/48022799/147845013-73dbda5b-500d-4f5a-ae51-3751d9268fe6.png)
 
 1. Click the `Download FutureRestore` button to fetch the latest version of FutureRestore
-** Note:** If your device supports iOS 15 or is a WiFi only-iPad, you will need to click the `Settings` button and enable `Futurerestore Beta`, then click the `Download FutureRestore` button. This version of futurerestore **requires** macOS or Linux.
+** Note:** If your device supports iOS 15 or is a WiFi only-iPad, you will need to click the `Settings` button and enable `Futurerestore Beta`, then click the `Download FutureRestore` button. 
 1. Click the `Select Blob File...` button and select your blob .shsh2 file
 1. Click the `Select Target iPSW File...` and select your .ipsw file
 1. Then click the Next button to navigate to the Options menu, make sure `Extra Logs` is enabled
 1. If you are not downgrading, then it is safe to enable `Preserve Data` in the options menu in order to keep data. However using it while downgrading may be dangerous
 1. Do not enable `AP Nonce Collision` on any modern devices
-1. Click Next to navigate to the controls menu
-1. Click `Start Futurerestore`
+2. Enable `Custom Latest` and input `15.7` into the box
+3. Enable `No RSEP` 
+4. Click Next to navigate to the controls menu
+5. Click `Start Futurerestore`
 
 If you experience any issues during the Process, look in the <router-link to="/futurerestore-help">FutureRestore help page</router-link>, if you still can't find a solution, ask in the #futurerestore-help channel on the r/jailbreak [Discord Server](https://discord.gg/9apvC4C3CC).

--- a/docs/en_US/updating/futurerestore.md
+++ b/docs/en_US/updating/futurerestore.md
@@ -79,7 +79,7 @@ This method will not work for A9 devices. If you cannot jailbreak, you must foll
 ::: 
 
 1. Open the TrollNonce app 
-2. Select the `Set Nonce` option, then input the generator value you found in your blob into the box. Click `Set`
+2. Select the `Set Nonce` option, then input the generator value you found in your blob into the box. Tap `Set`
 
 ::: danger
 
@@ -108,4 +108,4 @@ You **must** make sure that the latest SEP/BB is compatible to the version you a
 4. Click Next to navigate to the controls menu
 5. Click `Start Futurerestore`
 
-If you experience any issues during the Process, look in the <router-link to="/futurerestore-help">FutureRestore help page</router-link>, if you still can't find a solution, ask in the #futurerestore-help channel on the r/jailbreak [Discord Server](https://discord.gg/9apvC4C3CC).
+If you experience any issues during the Process, look in the <router-link to="/futurerestore-help">FutureRestore help page</router-link>, if you still can't find a solution, ask in the #genius-bar thread on the r/jailbreak [Discord Server](https://discord.gg/9apvC4C3CC).

--- a/docs/en_US/updating/futurerestore.md
+++ b/docs/en_US/updating/futurerestore.md
@@ -19,6 +19,12 @@ If you are on iOS 15.2 or newer on an A11- device, you should follow [this](http
 - Blobs saved for the version you want to restore to
 - A jailbroken device **or** an A10+ device on 15.0-15.1.1
 
+::: danger
+
+You **must** make sure that the latest SEP/BB is compatible to the version you are attempting to restore to in order to prevent bootloops! To do so, please consult the [SEP/BB Chart](https://docs.google.com/spreadsheets/d/1Mb1UNm6g3yvdQD67M413GYSaJ4uoNhLgpkc7YKi3LBs/edit#gid=0). If a cell says "Compatible" then you are free to restore to that version.
+
+:::
+
 ## Downloads
 
 - The latest release of [FutureRestore-GUI](https://github.com/CoocooFroggy/FutureRestore-GUI/releases)
@@ -80,14 +86,9 @@ This method will not work for A9 devices. If you cannot jailbreak, you must foll
 
 1. Open the TrollNonce app 
 2. Select the `Set Nonce` option, then input the generator value you found in your blob into the box. Tap `Set`
-
-::: danger
-
-You **must** make sure that the latest SEP/BB is compatible to the version you are attempting to restore to in order to prevent bootloops! To do so, please consult the [SEP/BB Chart](https://docs.google.com/spreadsheets/d/1Mb1UNm6g3yvdQD67M413GYSaJ4uoNhLgpkc7YKi3LBs/edit#gid=0). If a cell says "Compatible" then you are free to restore to that version.
-
-:::
  
 ### On Computer 
+
 1. Connect your iDevice to your computer
 1. Make sure that your computer is trusted by your device
     - Optionally, you can create a full backup of your device through iTunes or Finder
@@ -108,4 +109,4 @@ You **must** make sure that the latest SEP/BB is compatible to the version you a
 4. Click Next to navigate to the controls menu
 5. Click `Start Futurerestore`
 
-If you experience any issues during the Process, look in the <router-link to="/futurerestore-help">FutureRestore help page</router-link>, if you still can't find a solution, ask in the #genius-bar thread on the r/jailbreak [Discord Server](https://discord.gg/9apvC4C3CC).
+If you experience any issues during the Process, look in the <router-link to="/futurerestore-help">FutureRestore help page</router-link>, if you still can't find a solution, ask in the #genius-bar forum on the r/jailbreak [Discord Server](https://discord.gg/9apvC4C3CC).

--- a/docs/en_US/updating/futurerestore.md
+++ b/docs/en_US/updating/futurerestore.md
@@ -17,7 +17,7 @@ If you are on iOS 15.2 or newer on an A11- device, you should follow [this](http
 ## Requirements
 
 - Blobs saved for the version you want to restore to
-- A jailbroken device **or** a device on 15.0-15.1.1
+- A jailbroken device **or** an A10+ device on 15.0-15.1.1
 
 ## Downloads
 
@@ -30,20 +30,22 @@ If you are on iOS 15.2 or newer on an A11- device, you should follow [this](http
   - The latest version of [TrollStore](https://github.com/opa334/TrollStore/releases)
   - The latest version of [TrollNonce](https://github.com/opa334/TrollNonce/releases)
 
-## Getting Started
+## Getting Started (Jailbroken)
 
 1. Open your package manager on your jailbroken iDevice
 1. Add [repo.1conan.com](https://repo.1conan.com) to your sources
 1. Download and install dimentio
 1. Download and install NewTerm2
+2. Proceed to [Finding the generator](#finding-the-generator)
 
-## Setting nonce
+## Getting Started (Non-Jailbroken)
 
-::: danger
+1. Navigate to the [TrollStore](https://github.com/opa334/TrollStore) GitHub page and follow the installation instructions for your device
+   - If "None" is listed and you cannot jailbreak or you do not have an A11- device, you will be unable to proceed further
+2. Once trollstore is installed, install the [TrollNonce](https://github.com/opa334/TrollNonce/releases) app through TrollStore
+3. Proceed to the next section
 
-If you're using unc0ver on iOS 14.6-14.8, you cannot use dimentio as libkrw isn't functioning. You should set your generator from unc0ver's settings instead.
-
-:::
+## Finding the generator
 
 1. Open your blob in a text editor and search for `generator`
    ![GeneratorExample](https://user-images.githubusercontent.com/48022799/117004373-aa0b6700-acee-11eb-8a70-c488163e349b.jpeg) 
@@ -53,12 +55,31 @@ If you're using unc0ver on iOS 14.6-14.8, you cannot use dimentio as libkrw isn'
 
 **NOTE:** If there is no generator value, try to remember which jailbreak you were using at the time of saving blobs. If you were using unc0ver, your generator is most likely `0x1111111111111111`, and if you were using Chimera/Odyssey/Taurine, your generator is most likely `0xbd34a880be0b53f3`
 
-3. Open NewTerm 2 on your iDevice and type the following command, where `[generator]` is the value you just grabbed: `su root -c 'dimentio [generator]'`
+## Setting the nonce (Jailbroken)
+
+::: danger
+
+If you're using unc0ver on iOS 14.6-14.8, you cannot use dimentio as libkrw isn't functioning. You should set your generator from unc0ver's settings instead.
+
+:::
+
+1. Open NewTerm 2 on your iDevice and type the following command, where `[generator]` is the value you just grabbed: `su root -c 'dimentio [generator]'`
     
 1. When asked for a password, enter your root password
     - By default, this is set to `alpine`, not your phone's password.
 1. Once the command executes, a lot of text should appear
 1. Near the end of the text, you should see the line `Set nonce to [generator]`
+
+## Setting the nonce (Unjailbroken)
+
+::: warning
+
+This method will not work for A9 devices. If you cannot jailbreak, you must follow [this](https://gist.github.com/nyuszika7h/aac55c97f7925cddcf5ec3167f85dfe8) guide.
+
+::: 
+
+1. Open the TrollNonce app 
+2. Select the `Set Nonce` option, then input the generator value you found in your blob into the box. Click `Set`
 
 ::: danger
 
@@ -73,10 +94,9 @@ You **must** make sure that the latest SEP/BB is compatible to the version you a
 1. Open FutureRestoreGUI on your computer
     - If prompted by Windows Defender, Windows Smartscreen or other anti-virus software, allow the program to run - it’s safe
 1. When opening FutureRestoreGUI, you should be greeted by this menu:
-![image](https://user-images.githubusercontent.com/48022799/147845013-73dbda5b-500d-4f5a-ae51-3751d9268fe6.png](https://media.discordapp.net/attachments/594022956313608204/1025256111479197756/unknown.png)
+![image](https://media.discordapp.net/attachments/594022956313608204/1025256111479197756/unknown.png)
 
-1. Click the `Download FutureRestore` button to fetch the latest version of FutureRestore
-** Note:** If your device supports iOS 15 or is a WiFi only-iPad, you will need to click the `Settings` button and enable `Futurerestore Beta`, then click the `Download FutureRestore` button. **This option is only available for macOS and Linux**
+1. Click the `Settings` button and enable `Futurerestore Beta`, then click the `Download FutureRestore` button. **This option is only available for macOS and Linux**
   - Windows users must download the beta from [here](https://cdn.discordapp.com/attachments/917198974555942942/1023188228972494858/futurerestore_292_local_win_x64.exe). Once that is done, press `Select FutureRestore Binary/Executable` and navigate to where you have downloaded the beta. Select the file and click `Open`
 1. Click the `Select Blob File...` button and select your blob .shsh2 file
 1. Click the `Select Target iPSW File...` and select your .ipsw file


### PR DESCRIPTION
- Restructured the guide by a decent amount
- Now divides the guide into jailbroken and non-jailbroken, with the latter utilizing TrollNonce for non-jailbroken devices (A9-A11 devices that cannot use TrollNonce have been linked to the iOS 15 downgrade gist)
- Uses futurerestore beta for all devices as it is available on every OS now
- Made the No RSEP and Custom Latest flag mandatory
- Included a warning to check SEP/BB compatibility before continuing (spreadsheet is linked)
- Various other tweaks to bring guide more up-to-date