### PR TITLE
Semantic change to make guide more clear.

### DIFF
--- a/docs/en_US/jailbreak/installing-palera1n.md
+++ b/docs/en_US/jailbreak/installing-palera1n.md
@@ -42,7 +42,7 @@ Please select your operating system:
     - If you've already cloned the repo, just run `cd palera1n`
 1. Open up a terminal window and `cd` to the directory
 1. Run `./palera1n.sh --tweaks <iOS version you're on> --semi-tethered`
-    - Put your device in DFU Mode before running this command
+    - Put your device in DFU Mode **before running this command**
     - The semi-tethered flag uses 5-10GB of storage and is also incompatible with 16GB devices, **don't include --semi-tethered in the command** if you are using a 16GB device or have less than 10GB free.
 
 ::::
@@ -68,7 +68,7 @@ If you are using a computer with an AMD Ryzen CPU, you will likely run into issu
 1. Clone the repo with `git clone --recursive https://github.com/palera1n/palera1n && cd palera1n`
     - If you've already cloned the repo, just run `cd palera1n`\
 1. Run `sudo ./palera1n.sh --tweaks <iOS version you're on> --semi-tethered`
-    - Put your device in DFU Mode before running this command
+    - Put your device in DFU Mode **before running this command**
     - The semi-tethered flag uses 5-10GB of storage and is also incompatible with 16GB devices, **don't include --semi-tethered in the command** if you are using a 16GB device or have less than 10GB free.
 
 ::::


### PR DESCRIPTION
I was following this guide and saw that the sentence "Put your device in DFU Mode before running this command" was put underneath the command (this is for Step 6 on Linux and Step 3 on macOS). 

I almost missed this step as it was not highlighted and because it came **after** the step itself.

I just made a small change to bold the part "before running this command" to draw more attention to it.

Thanks.