### PR TITLE
Update removing-palera1n.md

### DIFF
--- a/docs/en_US/jailbreak/restoring-root-filesystem/removing-palera1n.md
+++ b/docs/en_US/jailbreak/restoring-root-filesystem/removing-palera1n.md
@@ -24,7 +24,6 @@ Then, open a second terminal, and do the following steps with the other terminal
     - If you've already cloned the repo, just run `cd palera1n`
 2. Run `./palera1n.sh --restorerootfs <iOS version you're on>`
     - If you're using Linux, add `sudo` to the front of the command
-    - If you're using semi-tethered palera1n, add the `--semi-tethered` flag to the end of the command
     - If you're having an issue, add `--debug` to the end and use those logs to troubleshoot
 
 Your device should boot into iOS, and you can use the device as normal.


### PR DESCRIPTION
Hello, 

When I was restoring rootfs(reinstalled Palera1n later because did some weird stuff). The Palera1n guide on how to remove it said that if you did a semi-tethered jailbreak to add that tag. When I added that tag and ran Palera1n it said that it is already rootless and doesn't need that flag. This request is just to remove that from the instructions to make it clearer to any users who want to remove Palera1n(although idk why anyone would want to). 

Thanks,
The Dev
Discord: The Dev#2394