### PR TITLE
Fix meridian guide (same goes for other PR)

### DIFF
--- a/docs/en_US/jailbreak/using-totallynotspyware.md
+++ b/docs/en_US/jailbreak/using-totallynotspyware.md
@@ -21,6 +21,7 @@ redirect_from:
 pkgman: cydia
 extra_contributors:
   - TheHacker894
+  - WhitetailAni
 ---
 
 TotallyNotSpyware is capable of jailbreaking every 64-bit iOS device on firmware version 10.0 up to 10.3.3.
@@ -29,25 +30,45 @@ Note that the TotallyNotSpyware jailbreak is not “persistent” (meaning it do
 
 ::: warning
 
-Should you run into issues with this method for any reason, you can attempt to use <router-link to="/installing-doubleh3lix-(ipa)">doubleh3lix</router-link> if you are on an A7-A9(X) device or <router-link to="/installing-meridian-(ipa)">Meridian</router-link> if you are on an A10(X) device.
+Should you run into issues with this method for any reason, you can attempt to use <router-link to="/installing-doubleh3lix-(ipa)">doubleh3lix</router-link> if you are on an A7-A9(X) device or <router-link to="/installing-meridian-(ipa)">Meridian</router-link> if you are on an A10(X) device. 
+
+::: warning
+
+If you have an A10 or A10X device, you will need a macOS or Linux computer so f. Otherwise Cydia will not function.
 
 :::
 
-## Running TotallyNotSpyware
+## Running TotallyNotSpyware (A7-A9X)
 
 1. Open Safari on your iOS device
 1. Go to the [https://totally-not.spyware.lol/](https://totally-not.spyware.lol/) website
 1. Slide, left to right, on the `Slide for Spyware` slider
 1. Once you see the `Spyware announcement` prompt, press `noot noot`
    - If the device reboots without prompting this, try again.
-1. You'll recieve a prompt asking you to choose between jailbreaking with Meridian or jailbreaking with doubleH3lix, what option you should select depends on your device
-   - If your device is an A7-A9(X) device, you *should* select doubleh3lix.
-   - If your device is an A10(X) device, the only option which works is to select Meridian.
+1. You'll receive a prompt asking you to choose between jailbreaking with Meridian or jailbreaking with doubleH3lix; select doubleh3lix.
 1. After selecting what you wish to jailbreak with, press `OK`
 
 TotallyNotSpyware will now install the temporary jailbreak on your device. 
 
 To rejailbreak in the future, doing steps 1 through 4 should rejailbreak your device.
+
+## Running TotallyNotSpyware (A10/X)
+
+1. Open Safari on your iOS device
+1. Go to the [https://mineek.github.io/totallynotspyware/](https://mineek.github.io/totallynotspyware/) website
+1. Slide, left to right, on the `Slide for Spyware` slider
+1. Once you see the `Spyware announcement` prompt, press `noot noot`
+   - If the device reboots without prompting this, try again.
+1. The device will display a popup that it is downloading the bootstrap, press `give me teh pr0n`. This will only happen on the first jailbreak run.
+1. After selecting what you wish to jailbreak with, press `OK`
+1. Once the device resprings, **do not open Cydia.** Get a Lightning cable and connect your device to your computer.
+1. Ensure `iproxy` is installed, then run the command `iproxy 2222 22` in a Terminal window.
+1. Open another Terminal window and run the command `ssh root@localhost -p2222`. The password is `alpine`.
+1. Once you are connected with ssh, run the following three commands:
+`wget https://web.archive.org/web/*/https://repo.midnight.team/debs/cydia.deb`
+`dpkg -i cydia.deb`
+`killall SpringBoard`
+After you run the third command, the device will respring.
 
 ::: tip
 
@@ -56,9 +77,5 @@ Tap `Share` -> `Add to home screen` for easier access to TotallyNotSpyware.
 :::
 
 You should now be jailbroken with Cydia installed on your home screen. You can use Cydia to install <router-link to="/faq/#what-are-tweaks">tweaks</router-link>, themes and more.
-
-::: tip
-
-If you wish to use a more modern package manager, continue to <router-link to="/installing-zebra">Installing Zebra</router-link>
 
 :::


### PR DESCRIPTION
Using the original TNS link does not work for Meridian, and cydia needs to be updated with a specific deb to function - otherwise cydia cannot install anything as it errors with cydo error 255. So this provides how. It definitely needs some polishing - I don't write in the ios cfw guide style - but the basic info is there.

The reason there's two pull requests is I'm not very good at pull requests and only know how to do one file at a time...

Also, the Zebra note was removed as currently Zebra does not work on 64-bit iOS 9 or 10.