### PR TITLE
Clarify which version of palera1n to get for Linux

### DIFF
--- a/docs/en_US/jailbreak/installing-palera1n-rootless.md
+++ b/docs/en_US/jailbreak/installing-palera1n-rootless.md
@@ -26,6 +26,10 @@ If you are using Windows, you should follow <router-link to="/using-palen1x-root
 The version of [palera1n](https://github.com/palera1n/palera1n/releases) for your OS.
   - macOS users should generally get `palera1n-macos-universal`
   - Linux users should get whichever version corresponds to the architecture of the computer you're using
+    - This will be usually `palera1n-linux-x86_64`. Choose this one if you're unsure.
+    - If you're using a 32-bit computer, choose `palera1n-linux-x86`.
+    - If you're using an ARM computer (e.g. a Raspberry Pi), choose `palera1n-linux-armel` for 32-bit and `palera1n-linux-arm64` for 64-bit.
+
 
 ## Installing the jailbreak
 

--- a/docs/en_US/jailbreak/installing-palera1n.md
+++ b/docs/en_US/jailbreak/installing-palera1n.md
@@ -47,6 +47,9 @@ For those who are interested in using a setup that, while supporting less tweaks
 The version of [palera1n](https://github.com/palera1n/palera1n/releases) for your OS.
   - macOS users should generally get `palera1n-macos-universal`
   - Linux users should get whichever version corresponds to the architecture of the computer you're using
+    - This will be usually `palera1n-linux-x86_64`. Choose this one if you're unsure.
+    - If you're using a 32-bit computer, choose `palera1n-linux-x86`.
+    - If you're using an ARM computer (e.g. a Raspberry Pi), choose `palera1n-linux-armel` for 32-bit and `palera1n-linux-arm64` for 64-bit.
 
 ## Installing the jailbreak
 


### PR DESCRIPTION
This clarifies that `palera1n-linux-x86_64` is usually the correct choice, as I've seen too many people mistakenly download the arm64 version. It also adds further clarification to help with choosing for less common setups.