### PR TITLE
Change the wording of the A9(X) issue

### DIFF
--- a/docs/en_US/jailbreak/installing-palera1n.md
+++ b/docs/en_US/jailbreak/installing-palera1n.md
@@ -70,7 +70,7 @@ If you're using an Apple Silicon Mac and using a USB-C port to plug your cable/a
 
 ::: tip
 
-A9(X) and earlier devices have an issue where they will get stuck midway through this process in pongoOS. To work around this issue, you'll need to do the following:
+A9(X) and earlier devices might have an issue where they will get stuck midway through this process in pongoOS. To work around this issue, you'll need to do the following:
 
 1. In the terminal window, press `Control` + `C` on your keyboard
 1. Rerun the command that you just ran

--- a/docs/en_US/jailbreak/installing-palera1n.md
+++ b/docs/en_US/jailbreak/installing-palera1n.md
@@ -119,7 +119,7 @@ If you do have issues, get a USB-A to Lightning cable and, if necessary, also ge
 
 ::: tip
 
-A9(X) and earlier devices have an issue where they will get stuck midway through this process in pongoOS. To work around this issue, you'll need to do the following:
+A9(X) and earlier devices might have an issue where they will get stuck midway through this process in pongoOS. To work around this issue, you'll need to do the following:
 
 1. In the terminal window, press `Control` + `C` on your keyboard
 1. Rerun the command that you just ran


### PR DESCRIPTION
From my experience with Beta 7 on Linux (Arch), you don’t need to rerun the script on A8/A9 
(Tested on an iPhone 6S and iPad Mini 4)