### PR TITLE
sideloading-apps lil fixes

### DIFF
--- a/docs/en_US/guides/sideloading-apps.md
+++ b/docs/en_US/guides/sideloading-apps.md
@@ -81,7 +81,7 @@ AltServer is only compatible with iOS 12.2 and newer.
 
 ## Resigning Apps
 
-### Resigning using Reprovision Reborn
+### Resigning using ReProvision Reborn
 
 ::: tip
 
@@ -90,8 +90,8 @@ ReProvision Reborn is compatible with iOS 9 and newer
 :::
 
 1. Add the Havoc Repo to your preferred package manager ([havoc.app](https://havoc.app/))
-1. Install Reprovison Reborn
-1. Open Reprovision Reborn and follow all onscreen prompts
+1. Install ReProvison Reborn
+1. Open ReProvision Reborn and follow all onscreen prompts
     - You will be asked to enter your AppleID. This is only sent to Apple and no one else.
 
 ### Resigning using AltDaemon

--- a/docs/en_US/guides/sideloading-apps.md
+++ b/docs/en_US/guides/sideloading-apps.md
@@ -85,7 +85,7 @@ AltServer is only compatible with iOS 12.2 and newer.
 
 ::: tip
 
-ReProvision Reborn is compatible with iOS 9 and newer
+ReProvision Reborn is compatible with iOS 9 and newer.
 
 :::
 

--- a/docs/en_US/guides/sideloading-apps.md
+++ b/docs/en_US/guides/sideloading-apps.md
@@ -104,7 +104,7 @@ AltDaemon, which utilizes AltStore, is only compatible with iOS 12.2 and newer.
 
 AltDaemon allows AltStore to automatically re-sign these applications, without needing to connect to a computer running AltServer over local network.
 
-1. Add the Chariz repository to your preffered package manager ([repo.chariz.com](https://repo.chariz.com/))
+1. Add the Chariz repository to your preferred package manager ([repo.chariz.com](https://repo.chariz.com/))
 1. Download and install the "AltDaemon" tweak
 1. Close your package manager
 1. Sign any apps that are about to expire

--- a/docs/en_US/guides/sideloading-apps.md
+++ b/docs/en_US/guides/sideloading-apps.md
@@ -92,7 +92,7 @@ ReProvision Reborn is compatible with iOS 9 and newer.
 1. Add the Havoc Repo to your preferred package manager ([havoc.app](https://havoc.app/))
 1. Install ReProvison Reborn
 1. Open ReProvision Reborn and follow all onscreen prompts
-    - You will be asked to enter your AppleID. This is only sent to Apple and no one else.
+    - You will be asked to enter your Apple ID. This is only sent to Apple and no one else.
 
 ### Resigning using AltDaemon
 

--- a/docs/en_US/guides/sideloading-apps.md
+++ b/docs/en_US/guides/sideloading-apps.md
@@ -104,7 +104,7 @@ AltDaemon, which utilizes AltStore, is only compatible with iOS 12.2 and newer.
 
 AltDaemon allows AltStore to automatically re-sign these applications, without needing to connect to a computer running AltServer over local network.
 
-1. Add the Chariz repository to your package manager ([repo.chariz.com](https://repo.chariz.com/))
+1. Add the Chariz repository to your preffered package manager ([repo.chariz.com](https://repo.chariz.com/))
 1. Download and install the "AltDaemon" tweak
 1. Close your package manager
 1. Sign any apps that are about to expire


### PR DESCRIPTION
Think the changes are pretty self-explanatory, but whatever

- Fixed ReProvision Reborn having not-capitalised "p"
- Added a dot to make formatting consistent
- Apple ID is written separately
- Added "preferred" to make similar-steps-across-guides consistent