### PR TITLE
Add small note

### DIFF
--- a/docs/en_US/jailbreak/installing-patchstick.md
+++ b/docs/en_US/jailbreak/installing-patchstick.md
@@ -10,6 +10,7 @@ pkgman: none
 extra_contributors:
   - WhitetailAni
 ---
+Note: The Apple TV 1 is based on macOS, not iOS, but it is included on ios.cfw.guide anyways.
 
 Patchstick is capable of untether jailbreaking the Apple TV 1 on Apple TV Software 1.0 to 3.0.2.
 


### PR DESCRIPTION
The Apple TV 1 is based on macOS, not iOS, but it is included on the site because another site would be impractical.