### PR TITLE
Clarify usage of tabs

### DIFF
--- a/docs/en_US/jailbreak/installing-dopamine.md
+++ b/docs/en_US/jailbreak/installing-dopamine.md
@@ -49,7 +49,17 @@ If you already have TrollStore installed, you can skip this section.
 
 ::::: tabs
 
-:::: tab name="TrollHelperOTA (15.0 to 15.4.1 / A12 and later 15.5 to 15.6.1)" :default="true"
+:::: tab name=" " :default="true"
+
+::: warning
+
+Please select a tab from the above options corresponding to your device.
+
+:::
+
+::::
+
+:::: tab name="TrollHelperOTA (15.0 to 15.4.1 / A12 and later 15.5 to 15.6.1)"
 
 ::: warning
 


### PR DESCRIPTION
I don't expect this pull request to be merged, but I still want to raise to attention an issue people are having with the guide. The tabs appear to be confusing to some: rather than selecting the TrollInstallerX tab suitable for their device, they would leave the TrollInstallerOTA default option selected, and get stuck because the instructions are incorrect. I've seen this happen several times in the r/Jailbreak discord server. In my opinion, some change needs to be made here.

My suggestion with this pull request is to create a new default tab that contains no instructions, instead referring people to look at the tabs above and pick one. This should (mostly) force people to actually read the tabs, and reduce the possibility of forgetting to select a tab and following the default instructions just because they are default. In other words, one set of instructions shouldn't have "default" precedence over another option, as that would be making assumptions about someone's setup.

Another possibility is to entirely split these up into different pages using the "Installing JailbreakName (Method)" format that already exists and has precedent with other pages, such as "Installing Dopamine (Sideloadly)", "Installing unc0ver (Fugu14)", and so on.

It's true that a literate reader can be expected to read and select a tab, but the current page still has a bit of unnecessary confusion. The 3DS Guide has also has some redundancy in their instructions just to prevent some common mistakes (such as not one but *two* red warning boxes on the "Installing boot9strap (MSET9 CLI)" page reminding people to *not* skip Step 6 (which they shouldn't even be skipping in the first place), including one red warning box immediately above the link to the next page. So, accepting the 3DS Guide's instructions as a deliberate design choice, I think this is a valid point to raise, and something that does need fixing, even if this specific pull request isn't the one to fix it.