### PR TITLE
Update installing-socket.md

### DIFF
--- a/docs/en_US/jailbreak/installing-socket.md
+++ b/docs/en_US/jailbreak/installing-socket.md
@@ -16,6 +16,8 @@ Socket is capable of jailbreaking every 32-bit iOS device on firmware version 10
 
 Note that the Socket jailbreak is not “persistent” (meaning it does not remain installed after a reboot). You will need to re-run the exploit after every reboot. You will be instructed on how to do this.
 
+Please also note that currently, Terminal and mTerminal do not work with this Jailbreak method due to codeSigning issues. Please use a different jailbreak method, such as [h3lix](https://ios.cfw.guide/installing-h3lix/) if you plan on using these tweaks.
+
 Due to how custom applications are installed to the device, in most cases you will need to reinstall the Socket jailbreak application to your device every 7 days from your computer.
 
 We will use Sideloadly to install the application to your device.


### PR DESCRIPTION
From what I have just personally experienced and have found through my research and ([still ongoing support ticket ](https://discord.com/channels/624739448927682611/740700466681217075/1308151722052419757)on the [LegacyJailbreak Discord](https://discord.com/invite/bhDpTAu), if you have input for me or help, please LMK as if there is a workaround for this, this change isnt necessary, and this PR can be closed,) this note is incredibly necessary for software preservation, as IPA extraction NEEDS these tools, and if people are not aware of this, they may need to reset their device to undo the JB as Socket does not let you restore rootFS, and a restore could mean losing the app, which is the whole reason why they're jailbreaking. This should be an issue for Socket to fix, however, it's evident for now it has to just be a warning.