### PR TITLE
Update using-totallynotspyware.md

### DIFF
--- a/docs/en_US/jailbreak/using-totallynotspyware.md
+++ b/docs/en_US/jailbreak/using-totallynotspyware.md
@@ -30,54 +30,22 @@ Note that the TotallyNotSpyware jailbreak is not “persistent” (meaning it do
 
 The method that needs to be followed in order to jailbreak depends on your device, select the tab that fits your device and follow the subsequent steps.
 
-::::: tabs
-
-:::: tab name="tns-sockport (A7 to A9(X) devices)" :default="true"
-
-## Running tns-sockport
+## Running TotallyNotSpyware
 
 1. Open Safari on your iOS device
-1. Go to the [https://lukezgd.github.io/tns-sockport](https://lukezgd.github.io/tns-sockport) website
+1. Go to the [https://lukezgd.github.io/tns](https://lukezgd.github.io/tns) website
 1. Slide, left to right, on the `Slide for Spyware` slider
 1. Once you see the `Spyware announcement` prompt, press `noot noot`
    - If the device reboots without prompting this, try again.
 
-tns-sockport will now jailbreak your device. 
+TotallyNotSpyware will now jailbreak your device. 
 
 To rejailbreak in the future, repeat these steps
 
 ::: tip
 
-Tap `Share` -> `Add to home screen` for easier access to tns-sockport.
+Tap `Share` -> `Add to home screen` for easier access to TotallyNotSpyware.
 
 :::
-
-::::
-
-:::: tab name="MeridianFix (A10(X) devices)"
-
-## Running MeridianFix
-
-1. Open Safari on your iOS device
-1. Go to the website for your iOS version:
-   - If you're on iOS 10.3 to 10.3.3, go to [https://lukezgd.github.io/MeridianFix/substrate/index.html](https://lukezgd.github.io/MeridianFix/substrate/index.html)
-   - If you're on iOS 10.0 to 10.2.1, go to [https://lukezgd.github.io/MeridianFix/substitute/index.html](https://lukezgd.github.io/MeridianFix/substitute/index.html)
-1. Slide, left to right, on the `Slide for Spyware` slider
-1. Once you see the `Spyware announcement` prompt, press `noot noot`
-   - If the device reboots without prompting this, try again.
-
-MeridianFix will now jailbreak your device. 
-
-To rejailbreak in the future, repeat these steps
-
-::: tip
-
-Tap `Share` -> `Add to home screen` for easier access to MeridianFix.
-
-:::
-
-::::
-
-:::::
 
 You should now be jailbroken with Zebra installed on your home screen. You can use Zebra to install <router-link to="/faq/#what-are-tweaks">tweaks</router-link>, themes and more.


### PR DESCRIPTION
- It now uses a single site that redirects to the correct version of TNS for the user's iOS device and version
- I have renamed the heading back to "Running TotallyNotSpyware" for simplicity and consistency