### PR TITLE
Fix tab selection

### DIFF
--- a/docs/en_US/guides/troubleshooting.md
+++ b/docs/en_US/guides/troubleshooting.md
@@ -336,7 +336,7 @@ In May 2021, Procursus attempted to migrate to a version of dpkg that no longer 
 1. Click `Modify` below the app name and select `Downgrade` then choose the selected version that works best. 
 1. Another possible way to fix this issue is to log in via SSH. 
 1. This can be done by locating your Apple TV Devices IP address and using the command `ssh root@Apple TV IP Address` then using `alpine` as the password to log in.
-1. After logging in, type in the following command to add the repository of your choice: `scho "deb URL_ADDRESS`
+1. After logging in, type in the following command to add the repository of your choice: `echo deb URL_ADDRESS`
 
 #### Issues with respringing
 


### PR DESCRIPTION
The darkened tab is the current page selection shown but it's a bit off putting when it appears the "A10" tab is selected on the page.  Perhaps one could reverse it so the lighter-colored tab reflects the page viewing and the darker-colored tab reflects the page not in viewing.

<img width="761" height="391" alt="Screen Shot 2025-11-11 at 12 18 23 PM" src="https://github.com/user-attachments/assets/6c0e7bf2-3923-461e-9386-554904c33da2" />