### PR TITLE
📲 : Instructions bump for latest sileo required software flow.

### DIFF
--- a/docs/en_US/jailbreak/installing-dopamine.md
+++ b/docs/en_US/jailbreak/installing-dopamine.md
@@ -122,7 +122,9 @@ While you are now jailbroken at this point, we need to both update and install s
 1. Tap "Get"
 1. Tap the "Queued" bar at the bottom of the page
 1. Tap "Confirm"
-1. Once finished, tap `Restart SpringBoard Later`
+1. Once finished, tap `Reboot Device` (This is a userspace reboot, so no rejailbreak is required afterwards)
+1. Unlock device
+1. Open the Sileo app
 1. Go to the "Search" tab
 1. Search for `PreferenceLoader`
 1. Tap on `PreferenceLoader`


### PR DESCRIPTION
Minor docs bump based on my experience jailbreaking iOS 16.3 (iPhone 11 Pro Max) on Apr 11 2026.

Sileo forced me to reboot device after installing ElleKit. It did not give me an option to re-spring later as instructions suggest, see screenshot of post-ElleKit install screen.

<img width="1242" height="2688" alt="IMG_5222" src="https://github.com/user-attachments/assets/1f10e8ef-5aaa-42ac-a627-15a673cb6a3f" />

When I attempted to install `PrefrenceLoader` w/o reboot, the get option was greyed out. 

Presumably something has changed with Sileo where they now encourage this slightly different behavior? I'm 99.99% sure it was a soft-reboot and I didn't have to rejailbreak after this `Reboot Device` but it'd be nice if someone more involved w/Sileo development could confirm.

Just figured I'd bump the docs to reflect what I had to go through.