### PR TITLE
Added additional instructions in installing-electra.md

### DIFF
--- a/docs/en_US/jailbreak/installing-electra.md
+++ b/docs/en_US/jailbreak/installing-electra.md
@@ -11,6 +11,7 @@ pkgman: sileo
 extra_contributors:
   - TheHacker894
   - Alriceee
+  - kittymaxine
 ---
 
 Electra is a <router-link to="/types-of-jailbreak/#semi-untethered-jailbreaks">semi-untethered jailbreak</router-link>, meaning it requires an app to re-apply the exploit after a reboot.
@@ -70,3 +71,18 @@ If your device crashes or restarts unexpectedly and the jailbreak isn't installe
 :::
 
 You should now be jailbroken with Sileo installed on your home screen. You can use Sileo to install <router-link to="/faq/#what-are-tweaks">tweaks</router-link>, themes and more.
+
+While you are now jailbroken at this point, we need to both update and install some packages so that we're able to both update other packages and have stuff work properly
+
+## Installing necessary software
+
+1. Open the Sileo app
+1. Tap on the "Sources" tab
+1. Press the `+` icon in the top right corner
+1. Enter `https://kittymaxine.com/repo` and press "Add Source"
+1. Wait for the repo to load, then tap "Maxine's Repo"
+1. Tap "Packaging", then tap on `ElectraRepoFix`
+1. Tap "Get"
+1. Tap the "Queued" bar at the bottom of the page
+1. Tap "Confirm"
+1. Once finished, tap "Done"


### PR DESCRIPTION
Since https://repo.chimera.sh is down, a new repo must be added. Due to Electra recreating `/etc/apt/sources.list.d/electra.list` with every jailbreak, a package that constantly sets this source list to the correct repo URL must be used.