### PR TITLE
[Apple TV/blackb0x] Update guide to include the SSH password

### DIFF
--- a/docs/en_US/jailbreak/installing-blackb0x.md
+++ b/docs/en_US/jailbreak/installing-blackb0x.md
@@ -67,4 +67,4 @@ Your Apple TV may boot into recovery mode after using blackb0x. This is normal, 
 
 :::
 
-You should now be jailbroken with Kodi installed on your home screen. To install packages, you will need to use SSH. To gain access, run the command `ssh -oHostKeyAlgorithms=+ssh-dss root@apple.tv.ip.here`. You can find the IP address in Settings.
+You should now be jailbroken with Kodi installed on your home screen. To install packages, you will need to use SSH. To gain access, run the command `ssh -oHostKeyAlgorithms=+ssh-dss root@apple.tv.ip.here`. You can find the IP address in Settings. If prompted for a password, use `alpine`.


### PR DESCRIPTION
While attempting to use SSH on an Apple TV 3rd gen (A1469), I encountered an issue where attempting to run the SSH command, in which I was prompted for a password. After a bit of digging through the blackb0x repo's issues, I was able to find that the password is `alpine` - due to this not being present in the guide, I've made this pull request to add it.

SSH password source: https://github.com/NSSpiral/Blackb0x/pull/167/changes/db3364d840fb33b8f0d23efa9af9d68f4f7600e3